### PR TITLE
RSDK-11071 Return errors when frames are stale

### DIFF
--- a/src/module/main.cpp
+++ b/src/module/main.cpp
@@ -44,7 +44,7 @@ namespace vsdk = ::viam::sdk;
 // CONSTANTS BEGIN
 constexpr char service_name[] = "viam_orbbec";
 const float mmToMeterMultiple = 0.001;
-const int maxFrameAgeUs = 1e6;
+const int maxFrameAgeUs = 1e6;  // time until a frame is considered stale, in microseconds (equal to 1 sec)
 
 // CONSTANTS END
 
@@ -351,7 +351,6 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
 
 uint64_t getTimeSinceFrame(uint64_t imageTimeUs) {
     auto nowUs = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    VIAM_SDK_LOG(info) << abs(int(nowUs - imageTimeUs));
     return abs(int(nowUs - imageTimeUs));
 }
 // HELPERS END

--- a/src/module/main.cpp
+++ b/src/module/main.cpp
@@ -44,7 +44,7 @@ namespace vsdk = ::viam::sdk;
 // CONSTANTS BEGIN
 constexpr char service_name[] = "viam_orbbec";
 const float mmToMeterMultiple = 0.001;
-const double usToSecondsMutliple = 1e-6;
+const double usToSecondsMultiple = 1e-6;
 const int maxFrameAgeSeconds = 1;
 
 // CONSTANTS END
@@ -351,7 +351,7 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
 }
 
 double getTimeSinceFrame(uint64_t imageTimeus) {
-    double imageTimeSeconds = imageTimeus * usToSecondsMutliple;
+    double imageTimeSeconds = imageTimeus * usToSecondsMultiple;
     const auto now = std::chrono::system_clock::now().time_since_epoch();
     double currentTimeSeconds = std::chrono::duration_cast<std::chrono::duration<double>>(now).count();
     return currentTimeSeconds - imageTimeSeconds;

--- a/src/module/main.cpp
+++ b/src/module/main.cpp
@@ -350,10 +350,10 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
     return raw_camera_image{raw_camera_image::uniq(rawBuf, raw_camera_image::array_delete_deleter), encodedData.size()};
 }
 
-uint64_t getTimeSinceFrame(uint64_t imageTimeus) {
-    uint64_t imageTimeSeconds = imageTimeus * usToSecondsMutliple;
-    const auto now = std::chrono::system_clock::now();
-    uint64_t currentTimeSeconds = std::chrono::time_point_cast<std::chrono::seconds>(now).time_since_epoch().count();
+double getTimeSinceFrame(uint64_t imageTimeus) {
+    double imageTimeSeconds = imageTimeus * usToSecondsMutliple;
+    const auto now = std::chrono::system_clock::now().time_since_epoch();
+    double currentTimeSeconds = std::chrono::duration_cast<std::chrono::duration<double>>(now).count();
     return currentTimeSeconds - imageTimeSeconds;
 }
 // HELPERS END


### PR DESCRIPTION
If the camera becomes disconnected and we stop getting new frames, we now return an error after one second instead of returning stale frames. 

Tested that the error throws on get_image 1 second after disconnecting the device. 
![Screenshot from 2025-06-27 14-37-04](https://github.com/user-attachments/assets/3a0c397b-9640-422a-a388-a11c93b4543f)

