### PR TITLE
fix-segfault

### DIFF
--- a/src/module/main.cpp
+++ b/src/module/main.cpp
@@ -56,7 +56,7 @@ struct PointXYZRGB {
 
 struct ViamOBDevice {
     ~ViamOBDevice() {
-        VIAM_SDK_LOG(info) << "deleting ViamOBDevice " << serial_number << "\n";
+        std::cout << "deleting ViamOBDevice " << serial_number << "\n";
     }
     std::string serial_number;
     std::shared_ptr<ob::Device> device;


### PR DESCRIPTION
This destructor runs after main returns and therefor after the viam sdk has been destroyed. 
This change makes it so that no global objects try to access viam sdk objects after the viam sdk has been destroyed.

Long term fix would be to move all the global state into an orbbec module context object which has a shorter lifetime than the viam cpp sdk.