### PR TITLE
linux-x86-64-update-to-latest-sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,17 @@ OUTPUT_NAME = orbbec-module
 BIN := build-conan/build/RelWithDebInfo/orbbec-module
 TAG_VERSION?=latest
 APPIMAGE := packaging/appimages/deploy/$(OUTPUT_NAME)-$(TAG_VERSION)-$(ARCH).AppImage
-ORBBEC_SDK_VERSION=v2.4.3
-ORBBEC_SDK_COMMIT=045a0e76
 
 ifeq ($(OS),darwin)
-  ORBBEC_SDK_TIMESTAMP = 202505192200
+  ORBBEC_SDK_VERSION=v2.4.3
+  ORBBEC_SDK_COMMIT=045a0e76
+  ORBBEC_SDK_TIMESTAMP=202505192200
   ORBBEC_SDK_DIR = OrbbecSDK_$(ORBBEC_SDK_VERSION)_$(ORBBEC_SDK_TIMESTAMP)_$(ORBBEC_SDK_COMMIT)_macOS_beta
 else ifeq ($(OS),linux)
   ifeq ($(ARCH),x86_64)
-    ORBBEC_SDK_TIMESTAMP = 202505191331
+    ORBBEC_SDK_VERSION=v2.4.8
+    ORBBEC_SDK_COMMIT=ec8e3469
+    ORBBEC_SDK_TIMESTAMP = 202507031325
     ORBBEC_SDK_DIR = OrbbecSDK_$(ORBBEC_SDK_VERSION)_$(ORBBEC_SDK_TIMESTAMP)_$(ORBBEC_SDK_COMMIT)_linux_$(ARCH)
   else
     $(error Unsupported architecture: $(ARCH))
@@ -26,6 +28,7 @@ endif
 
 module.tar.gz: $(BIN) meta.json
 ifeq ($(OS),linux)
+	@make $(APPIMAGE)
 	mv $(APPIMAGE) $(OUTPUT_NAME)
 	tar -czvf module.tar.gz \
 		$(OUTPUT_NAME) \

--- a/packaging/appimages/orbbec-module-x86_64.yml
+++ b/packaging/appimages/orbbec-module-x86_64.yml
@@ -3,7 +3,7 @@ script:
  - rm -rf AppDir || true
  - mkdir -p $TARGET_APPDIR/usr/bin $TARGET_APPDIR/usr/lib 
  - cp ../../build-conan/build/RelWithDebInfo/orbbec-module $TARGET_APPDIR/usr/bin/
- - cp -r ../../OrbbecSDK_v2.4.3_202505191331_045a0e76_linux_x86_64/lib/ $TARGET_APPDIR/usr/lib/
+ - cp -r ../../OrbbecSDK_v2.4.8_202507031325_ec8e3469_linux_x86_64/lib/ $TARGET_APPDIR/usr/lib/
  - mkdir -p $TARGET_APPDIR/usr/share/icons/viam/256x256/apps/
  - cp ./viam-server.png $TARGET_APPDIR/usr/share/icons/viam/256x256/apps/viam-server.png
  - go install github.com/Otterverse/aix@latest


### PR DESCRIPTION
also fix the fact that `make` is broken on linux as we no longer create the app image due to https://github.com/viam-modules/orbbec/commit/4a432eaf31c85c65a439f7b34fb22f00972bb72e#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L14-L15