### PR TITLE
RSDK-11419: Change to always rebuild

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -70,7 +70,7 @@ else
 fi
 
 # NOTE: If you change this version, also change it in the `conanfile.py` requirements
-git checkout releases/v0.15.0
+git checkout releases/v0.16.0
 
 # Build the C++ SDK repo
 #

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,7 +42,7 @@ class orbbec(ConanFile):
     def requirements(self):
         # NOTE: If you update the `viam-cpp-sdk` dependency here, it
         # should also be updated in `bin/setup.{sh,ps1}`.
-        self.requires("viam-cpp-sdk/0.15.0")
+        self.requires("viam-cpp-sdk/0.16.0")
 
     def generate(self):
         tc = CMakeToolchain(self)


### PR DESCRIPTION
Validates the fix in Viam C++ SDK version 0.16.0 to fix the always-rebuild logic. After removing `Reconfigurable` from `Orbbec` I was able to reconfigure the resource and verify in the logs that the destructor and constructor were firing. Let me know what additional validation I should be doing 