### PR TITLE
RSDK-11302 bug fix reconfigure causes no recent frame error 

### DIFF
--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -656,6 +656,7 @@ vsdk::Camera::image_collection Orbbec::get_images() {
             buffer << "no recent color frame: check USB connection, diff: " << diff << "us";
             throw std::invalid_argument(buffer.str());
         }
+
         if (color->getFormat() != OB_FORMAT_MJPG) {
             throw std::invalid_argument("color frame was not in jpeg format");
         }

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -353,16 +353,6 @@ auto frameCallback(const std::string& serialNumber) {
     };
 }
 
-void resetDevice(std::unique_ptr<ViamOBDevice>& dev) {
-    VIAM_SDK_LOG(info) << service_name << ": resetting device " << dev->serial_number;
-
-    dev->pipe->stop();
-    dev->started = false;
-    dev->pipe->start(dev->config, frameCallback(dev->serial_number));
-    dev->started = true;
-    VIAM_SDK_LOG(info) << service_name << ": device reset " << dev->serial_number;
-}
-
 void startDevice(std::string serialNumber) {
     VIAM_SDK_LOG(info) << service_name << ": starting device " << serialNumber;
     std::lock_guard<std::mutex> lock(devices_by_serial_mu());
@@ -400,7 +390,10 @@ void startDevice(std::string serialNumber) {
 
     if (!got_frame) {
         VIAM_SDK_LOG(info) << "did not get frame within 500ms, resetting";
-        resetDevice(my_dev);
+        my_dev->pipe->stop();
+        my_dev->started = false;
+        my_dev->pipe->start(dev->config, frameCallback(my_dev->serial_number));
+        my_dev->started = true;
     }
 
     VIAM_SDK_LOG(info) << service_name << ": device started " << serialNumber;

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -381,8 +381,7 @@ void startDevice(std::string serialNumber) {
     while (std::chrono::steady_clock::now() - start_time < std::chrono::milliseconds(500)) {
         {
             std::lock_guard<std::mutex> lock(frame_set_by_serial_mu());
-            auto search = frame_set_by_serial().find(serialNumber);
-            if (search != frame_set_by_serial().end()) {
+            if (frame_set_by_serial().count(serialNumber) > 0) {
                 got_frame = true;
                 break;
             }

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -366,7 +366,6 @@ void startDevice(std::string serialNumber) {
         throw std::invalid_argument(buffer.str());
     }
 
-
     // Check if the device is an Astra 2
     std::shared_ptr<ob::DeviceInfo> deviceInfo = search->second->device->getDeviceInfo();
     if (!strstr(deviceInfo->name(), "Astra 2")) {

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -394,7 +394,7 @@ void startDevice(std::string serialNumber) {
         VIAM_SDK_LOG(error) << "did not get frame within 500ms of starting device, resetting";
         my_dev->pipe->stop();
         my_dev->started = false;
-        my_dev->pipe->start(dev->config, frameCallback(my_dev->serial_number));
+        my_dev->pipe->start(my_dev->config, frameCallback(serialNumber));
         my_dev->started = true;
     }
 
@@ -656,8 +656,6 @@ vsdk::Camera::image_collection Orbbec::get_images() {
             buffer << "no recent color frame: check USB connection, diff: " << diff << "us";
             throw std::invalid_argument(buffer.str());
         }
-        }
-
         if (color->getFormat() != OB_FORMAT_MJPG) {
             throw std::invalid_argument("color frame was not in jpeg format");
         }
@@ -730,11 +728,9 @@ vsdk::Camera::point_cloud Orbbec::get_point_cloud(std::string mime_type, const v
     try {
         VIAM_SDK_LOG(info) << "[get_point_cloud] start";
         std::string serial_number;
-        std::string resource_name;
         {
             const std::lock_guard<std::mutex> lock(config_mu_);
             serial_number = config_->serial_number;
-            resource_name = config_->resource_name;
         }
         std::shared_ptr<ob::FrameSet> fs = nullptr;
         {

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -371,8 +371,7 @@ void startDevice(std::string serialNumber, std::string resourceName) {
         throw std::invalid_argument(buffer.str());
     }
 
-    auto cb = frameCallback(serialNumber);
-    my_dev->pipe->start(my_dev->config, cb);
+    my_dev->pipe->start(my_dev->config, frameCallback(serialNumber));
     my_dev->started = true;
     VIAM_SDK_LOG(info) << service_name << ": device started " << serialNumber;
 }
@@ -420,8 +419,7 @@ void resetDevice(std::string serialNumber) {
 
     my_dev->pipe->stop();
     my_dev->started = false;
-    auto cb = frameCallback(serialNumber);
-    my_dev->pipe->start(my_dev->config, cb);
+    my_dev->pipe->start(my_dev->config, frameCallback(serialNumber));
     my_dev->started = true;
     VIAM_SDK_LOG(info) << service_name << ": device reset " << serialNumber;
 }
@@ -580,7 +578,7 @@ vsdk::Camera::raw_image Orbbec::get_image(std::string mime_type, const vsdk::Pro
                     throw std::invalid_argument(buffer.str());
                 }
             }
-            // otherwise restart the pipeline to try to get frames again.
+            // USB still connected, restart the pipeline to try to get frames again.
             VIAM_SDK_LOG(info) << "device still connected but not getting frames, restarting pipeline";
             resetDevice(serial_number);
             throw std::invalid_argument(buffer.str());
@@ -698,7 +696,7 @@ vsdk::Camera::image_collection Orbbec::get_images() {
                         throw std::invalid_argument(buffer.str());
                     }
                 }
-                // otherwise restart the pipeline to try to get frames again.
+                // USB still connected, restart the pipeline to try to get frames again.
                 VIAM_SDK_LOG(info) << "device still connected but not getting frames, restarting pipeline";
                 resetDevice(serial_number);
                 throw std::invalid_argument(buffer.str());
@@ -729,7 +727,7 @@ vsdk::Camera::image_collection Orbbec::get_images() {
                         throw std::invalid_argument(buffer.str());
                     }
                 }
-                // otherwise restart the pipeline to try to get frames again.
+                // USB still connected, restart the pipeline to try to get frames again.
                 VIAM_SDK_LOG(info) << "device still connected but not getting frames, restarting pipeline";
                 resetDevice(serial_number);
                 throw std::invalid_argument(buffer.str());
@@ -826,7 +824,7 @@ vsdk::Camera::point_cloud Orbbec::get_point_cloud(std::string mime_type, const v
                     throw std::invalid_argument(buffer.str());
                 }
             }
-            // otherwise restart the pipeline to try to get frames again.
+            // USB still connected, restart the pipeline to try to get frames again.
             VIAM_SDK_LOG(info) << "device still connected but not getting frames, restarting pipeline";
             resetDevice(serial_number);
             throw std::invalid_argument(buffer.str());
@@ -849,7 +847,7 @@ vsdk::Camera::point_cloud Orbbec::get_point_cloud(std::string mime_type, const v
                     throw std::invalid_argument(buffer.str());
                 }
             }
-            // otherwise restart the pipeline to try to get frames again.
+            // USB still connected, restart the pipeline to try to get frames again.
             VIAM_SDK_LOG(info) << "device still connected but not getting frames, restarting pipeline";
             resetDevice(serial_number);
             throw std::invalid_argument(buffer.str());


### PR DESCRIPTION
On some reconfigures, the orbbec pipeline gets into a bad state where both streams appear to start up successfully (no indication of failure in debug logs) but no depth frames are ever received. This PR will recover from that state by resetting the pipeline if we don't start getting frames after starting the device. Users will see the following logs:
```

8/14/2025, 1:06:08 PM info rdk.resource_manager   impl/resource_manager.go:779   Successfully reconfigured resource   resource rdk:component:camera/camera-1  model viam:orbbec:astra2

8/14/2025, 1:06:08 PM info Viam C++ SDK     [module/orbbec.cpp:518] Orbbec reconfigure end   log_ts 2025-08-14T13:06:08.211Z

8/14/2025, 1:06:08 PM info Viam C++ SDK     [module/orbbec.cpp:400] viam_orbbec: device started AARH73P000L   log_ts 2025-08-14T13:06:08.210Z

8/14/2025, 1:06:08 PM error Viam C++ SDK     [module/orbbec.cpp:393] did not get frame within 500ms of starting device, resetting   log_ts 2025-08-14T13:06:08.192Z

8/14/2025, 1:06:08 PM info Viam C++ SDK     [module/orbbec.cpp:357] viam_orbbec: starting device AARH73P000L   log_ts 2025-08-14T13:06:08.170Z

8/14/2025, 1:06:08 PM info Viam C++ SDK     [module/orbbec.cpp:489] Orbbec reconfigure start   log_ts 2025-08-14T13:06:08.162Z

8/14/2025, 1:06:08 PM info rdk.modmanager.local-module-1   modmanager/manager.go:573   Reconfiguring resource for module   resource camera-1  module local-module-1

8/14/2025, 1:06:08 PM info rdk.resource_manager   impl/resource_manager.go:728   Now reconfiguring resource   resource rdk:component:camera/camera-1  model viam:orbbec:astra2

8/14/2025, 1:06:08 PM info rdk   impl/local_robot.go:1487   (Re)configuring robot
```

After this code change when reconfiguring, I no longer see the no frames yet error and can see new frames every time without restarting the server. 