### PR TITLE
RSDK-11508 fix current frame vs previous frame timestamp calculation

### DIFF
--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -356,13 +356,15 @@ void startDevice(std::string serialNumber, std::string resourceName) {
             if (prevColor != nullptr && prevDepth != nullptr) {
                 diff = timeSinceFrameUs(color->getSystemTimeStampUs(), prevColor->getSystemTimeStampUs());
                 if (diff > maxFrameAgeUs) {
-                    std::cerr << "previous color frame is " << diff << "us older than current color frame. nowUs: " << nowUs
-                              << " frameTimeUs " << color->getSystemTimeStampUs() << "\n";
+                    std::cerr << "previous color frame is " << diff
+                              << "us older than current color frame. previousUs: " << prevColor->getSystemTimeStampUs()
+                              << " currentUs: " << color->getSystemTimeStampUs() << "\n";
                 }
                 diff = timeSinceFrameUs(depth->getSystemTimeStampUs(), prevDepth->getSystemTimeStampUs());
                 if (diff > maxFrameAgeUs) {
-                    std::cerr << "previous depth frame is " << diff << "us older than current depth frame. nowUs: " << nowUs
-                              << " frameTimeUs " << depth->getSystemTimeStampUs() << "\n";
+                    std::cerr << "previous depth frame is " << diff
+                              << "us older than current depth frame. previousUs: " << prevDepth->getSystemTimeStampUs()
+                              << " currentUs: " << depth->getSystemTimeStampUs() << "\n";
                 }
             }
         }


### PR DESCRIPTION
Previously we were comparing current frame to current frame. This code change obtains the previous frames from the frame_set_by_serial map to compare current frame timestamp to previous frame timestamps. Also changed the logs to include the previous time stamp.  Now we can see logs like this:
```
8/14/2025, 4:49:24 PM error rdk.modmanager.local-module-1.StdErr   pexec/managed_process.go:396   \_ previous depth frame is 12053000us older than current depth frame. previousUs: 1755204552567072 currentUs: 1755204564620072

8/14/2025, 4:49:24 PM error rdk.modmanager.local-module-1.StdErr   pexec/managed_process.go:396   \_ previous color frame is 12073857us older than current color frame. previousUs: 1755204552554925 currentUs: 1755204564628782
```

Tested by unplugging the USB for a few seconds then replugging. 