### PR TITLE
RSDK-11689 do config validation in validate, change configure_ to configure

### DIFF
--- a/src/module/main.cpp
+++ b/src/module/main.cpp
@@ -16,9 +16,12 @@ std::vector<std::shared_ptr<vsdk::ModelRegistration>> create_all_model_registrat
     std::vector<std::shared_ptr<vsdk::ModelRegistration>> registrations;
 
     registrations.push_back(std::make_shared<vsdk::ModelRegistration>(
-        vsdk::API::get<vsdk::Camera>(), orbbec::Orbbec::model, [](vsdk::Dependencies deps, vsdk::ResourceConfig config) {
+        vsdk::API::get<vsdk::Camera>(),
+        orbbec::Orbbec::model,
+        [](vsdk::Dependencies deps, vsdk::ResourceConfig config) {
             return std::make_unique<orbbec::Orbbec>(std::move(deps), std::move(config));
-        }));
+        },
+        orbbec::validate));
 
     registrations.push_back(std::make_shared<vsdk::ModelRegistration>(
         vsdk::API::get<vsdk::Discovery>(), discovery::OrbbecDiscovery::model, [ctx](vsdk::Dependencies deps, vsdk::ResourceConfig config) {

--- a/src/module/main.cpp
+++ b/src/module/main.cpp
@@ -21,7 +21,7 @@ std::vector<std::shared_ptr<vsdk::ModelRegistration>> create_all_model_registrat
         [](vsdk::Dependencies deps, vsdk::ResourceConfig config) {
             return std::make_unique<orbbec::Orbbec>(std::move(deps), std::move(config));
         },
-        orbbec::validate));
+        orbbec::Orbbec::validate));
 
     registrations.push_back(std::make_shared<vsdk::ModelRegistration>(
         vsdk::API::get<vsdk::Discovery>(), discovery::OrbbecDiscovery::model, [ctx](vsdk::Dependencies deps, vsdk::ResourceConfig config) {

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -451,7 +451,7 @@ std::vector<std::string> Orbbec::validate(vsdk::ResourceConfig cfg) {
         throw std::invalid_argument("serial_number must be a string");
     }
 
-    // We already stablished this is a string, so it's safe to call this
+    // We already established this is a string, so it's safe to call this
     std::string const serial = attrs["serial_number"].get_unchecked<std::string>();
     if (serial.empty()) {
         throw std::invalid_argument("serial_number must be a non-empty string");

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -443,16 +443,26 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
 std::vector<std::string> validate(vsdk::ResourceConfig cfg) {
     auto attrs = cfg.attributes();
 
+    if (not attrs.count("serial_number")) {
+        throw std::invalid_argument("serial_number is a required argument");
+    }
+
     if (attrs.count("serial_number")) {
         if (!attrs["serial_number"].get<std::string>()) {
             throw std::invalid_argument("serial_number must be a string");
         }
     }
+
+    // We already stablished this is a string, so it's safe to call this
+    std::string const serial = attrs["serial_number"].get_unchecked<std::string>();
+    if (serial.empty()) {
+        throw std::invalid_argument("serial_number must be a non-empty string");
+    }
     return {};
 }
 
 Orbbec::Orbbec(vsdk::Dependencies deps, vsdk::ResourceConfig cfg)
-    : Camera(cfg.name()), config_(configure_(std::move(deps), std::move(cfg))) {
+    : Camera(cfg.name()), config_(configure(std::move(deps), std::move(cfg))) {
     VIAM_SDK_LOG(info) << "Orbbec constructor start " << config_->serial_number;
     startDevice(config_->serial_number, config_->resource_name);
     {
@@ -498,7 +508,7 @@ void Orbbec::reconfigure(const vsdk::Dependencies& deps, const vsdk::ResourceCon
     {
         const std::lock_guard<std::mutex> lock(config_mu_);
         config_.reset();
-        config_ = configure_(deps, cfg);
+        config_ = configure(deps, cfg);
         new_serial_number = config_->serial_number;
         new_resource_name = config_->resource_name;
     }
@@ -801,23 +811,12 @@ std::vector<vsdk::GeometryConfig> Orbbec::get_geometries(const vsdk::ProtoStruct
     return {vsdk::GeometryConfig(vsdk::pose{-37.5, 5.5, -18.1}, vsdk::box({145, 46, 39}), "box")};
 }
 
-std::unique_ptr<orbbec::ObResourceConfig> Orbbec::configure_(vsdk::Dependencies dependencies, vsdk::ResourceConfig configuration) {
+std::unique_ptr<orbbec::ObResourceConfig> Orbbec::configure(vsdk::Dependencies dependencies, vsdk::ResourceConfig configuration) {
     auto attrs = configuration.attributes();
-
     std::string serial_number_from_config;
-    if (!attrs.count("serial_number")) {
-        throw std::invalid_argument("serial_number is a required argument");
-    }
-
     const std::string* serial_val = attrs["serial_number"].get<std::string>();
-    if (serial_val == nullptr) {
-        throw std::invalid_argument("serial_number must be a string");
-    }
-
     serial_number_from_config = *serial_val;
-
     auto native_config = std::make_unique<orbbec::ObResourceConfig>(serial_number_from_config, configuration.name());
-
     return native_config;
 }
 // RESOURCE END

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -440,17 +440,15 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
 // HELPERS END
 
 // RESOURCE BEGIN
-std::vector<std::string> validate(vsdk::ResourceConfig cfg) {
+std::vector<std::string> Orbbec::validate(vsdk::ResourceConfig cfg) {
     auto attrs = cfg.attributes();
 
     if (not attrs.count("serial_number")) {
         throw std::invalid_argument("serial_number is a required argument");
     }
 
-    if (attrs.count("serial_number")) {
-        if (!attrs["serial_number"].get<std::string>()) {
-            throw std::invalid_argument("serial_number must be a string");
-        }
+    if (!attrs["serial_number"].get<std::string>()) {
+        throw std::invalid_argument("serial_number must be a string");
     }
 
     // We already stablished this is a string, so it's safe to call this

--- a/src/module/orbbec.hpp
+++ b/src/module/orbbec.hpp
@@ -18,7 +18,6 @@ struct ObResourceConfig {
 
 void startOrbbecSDK(ob::Context& ctx);
 void printDeviceInfo(const std::shared_ptr<ob::DeviceInfo> info);
-std::vector<std::string> validate(viam::sdk::ResourceConfig cfg);
 
 class Orbbec final : public viam::sdk::Camera, public viam::sdk::Reconfigurable {
    public:
@@ -32,6 +31,7 @@ class Orbbec final : public viam::sdk::Camera, public viam::sdk::Reconfigurable 
     properties get_properties() override;
     std::vector<viam::sdk::GeometryConfig> get_geometries(const viam::sdk::ProtoStruct& extra) override;
 
+    static std::vector<std::string> validate(viam::sdk::ResourceConfig cfg);
     static viam::sdk::GeometryConfig geometry;
     static viam::sdk::Model model;
 

--- a/src/module/orbbec.hpp
+++ b/src/module/orbbec.hpp
@@ -18,6 +18,7 @@ struct ObResourceConfig {
 
 void startOrbbecSDK(ob::Context& ctx);
 void printDeviceInfo(const std::shared_ptr<ob::DeviceInfo> info);
+std::vector<std::string> validate(viam::sdk::ResourceConfig cfg);
 
 class Orbbec final : public viam::sdk::Camera, public viam::sdk::Reconfigurable {
    public:
@@ -37,7 +38,7 @@ class Orbbec final : public viam::sdk::Camera, public viam::sdk::Reconfigurable 
    private:
     std::unique_ptr<ObResourceConfig> config_;
     std::mutex config_mu_;
-    static std::unique_ptr<ObResourceConfig> configure_(viam::sdk::Dependencies deps, viam::sdk::ResourceConfig cfg);
+    static std::unique_ptr<ObResourceConfig> configure(viam::sdk::Dependencies deps, viam::sdk::ResourceConfig cfg);
 };
 
 }  // namespace orbbec


### PR DESCRIPTION
This moves all of the config validation to the validate function, and includes validate in the model registration. 
Also changing configure_ to configure since the _ suffix is usually only used on member variables.

Tested that configure/reconfigure works and the expected validation checks error when the config is invalid. 