### PR TITLE
Dry run workflow dispatch in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Build & publish module to registry
 on:
   release:
     types: [published]
-  workflow_trigger:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Build & publish module to registry
 on:
   release:
     types: [published]
+  workflow_trigger:
 
 jobs:
   build:
@@ -48,6 +49,8 @@ jobs:
 
   publish:
     needs: build
+    # If the workflow was manually triggered it will be a dry run that does not push to the registry.
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/viamrobotics/rdk-devenv:amd64


### PR DESCRIPTION
I believe this will allow us to test #41 and could be useful in general--adds a workflow trigger option for publish.yml which does not upload the build artifacts to the registry. 

I think this needs to be merged to main before we can actually test manual dry-run on #41 