### PR TITLE
RSDK-11085 support windows AMD64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
             container:
               image: ghcr.io/viamrobotics/rdk-devenv:arm64
               options: --platform linux/arm64
+          - os: windows-latest
+
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,9 @@ jobs:
             container:
               image: ghcr.io/viam-modules/orbbec/viam-cpp-base-orin:0.0.1
             artifact-name: module-linux-arm64
+          - platform: windows/amd64
+            os: windows-latest
+            artifact-name: module-windows-amd64
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,12 @@ project(viam-orbbec
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake")
 
-# Here we set the rpath to accomodate one and only one supported deployment
-# case, a directory containing
+# Here we set the rpath to accomodate the deployment case, a directory containing
 # ├── bin
 # │   └── orbbec-module
 # ├── lib
 #     └── <runtime dependencies>
+# On Windows the directory structure is flat
 if (APPLE)
     list(PREPEND CMAKE_INSTALL_RPATH "@loader_path/../lib")
 else()
@@ -65,22 +65,39 @@ if (APPLE)
     set(_framework_dest_arg "FRAMEWORK" "DESTINATION" "lib")
 endif()
 
-install(
-    TARGETS orbbec-module
-    RUNTIME_DEPENDENCIES
-		POST_EXCLUDE_REGEXES ${_post_exclude_regex}
-    RUNTIME
-    LIBRARY
-    ${_framework_dest_arg}
-)
 
-# The lib/extensions directory contains some shared libraries which are
-# mandatory for our use case but not picked up by the runtime dependency set
-# because they are loaded at runtime.
-install(
-    DIRECTORY ${OrbbecSDK_DIR}/extensions
-    DESTINATION lib
-)
+if (WIN32)
+    # Install the target without scanning system DLLs
+    install(TARGETS orbbec-module
+        RUNTIME
+    )
+    install(FILES "${OrbbecSDK_DIR}/orbbecsdk.dll" DESTINATION bin)
+    install(DIRECTORY "${OrbbecSDK_DIR}/extensions" DESTINATION bin)
+
+else()
+    install(
+        TARGETS orbbec-module
+        RUNTIME_DEPENDENCIES
+            POST_EXCLUDE_REGEXES ${_post_exclude_regex}
+        RUNTIME
+        LIBRARY
+        ${_framework_dest_arg}
+    )
+    install(
+        PROGRAMS
+            first_run.sh
+            install_udev_rules.sh
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
+    )
+    # The lib/extensions directory contains some shared libraries which are
+    # mandatory for our use case but not picked up by the runtime dependency set
+    # because they are loaded at runtime.
+    install(
+        DIRECTORY ${OrbbecSDK_DIR}/extensions
+        DESTINATION lib
+        )
+endif()
+
 
 install(
     FILES
@@ -89,9 +106,3 @@ install(
     DESTINATION ${CMAKE_INSTALL_PREFIX}
 )
 
-install(
-    PROGRAMS
-        first_run.sh
-        install_udev_rules.sh
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
-)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ ifeq ($(OS),Windows_NT)
   # syntax, which calls powershell for us and explicitly sets the
   # exit status so we terminate make on error.
 	SCRIPT_EXT := .bat
+	SHELL := cmd
 	SUBSHELL := cmd /C
 	PATHSEP := \\
 else

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ conan-pkg:
 ifeq ($(OS),Windows_NT)
 # no first run on windows, remove it from meta.json
 	cmd /C powershell -Command "$$json = Get-Content 'meta.json' -Raw | ConvertFrom-Json; $$json.PSObject.Properties.Remove('first_run') | Out-Null; $$json | ConvertTo-Json -Depth 2 | Set-Content 'meta.json'"
-	cmd /C "IF EXIST .\venv\Scripts\activate.bat call .\venv\Scripts\activate.bat && conan create . -o:a "viam-cpp-sdk/*:shared=False" -s:a build_type=Release -s:a compiler.cppstd=17 --build=missing"
+	cmd /C "refreshenv && IF EXIST .\venv\Scripts\activate.bat call .\venv\Scripts\activate.bat && conan create . -o:a "viam-cpp-sdk/*:shared=False" -s:a build_type=Release -s:a compiler.cppstd=17 --build=missing"
 else
 	test -f ./venv/bin/activate && . ./venv/bin/activate; \
 	conan create . \
@@ -78,7 +78,7 @@ endif
 
 module.tar.gz: conan-pkg meta.json
 ifeq ($(OS),Windows_NT)
-	cmd /C "IF EXIST .\venv\Scripts\activate.bat call .\venv\Scripts\activate.bat && conan install --requires=viam-orbbec/0.0.1 -o:a "viam-cpp-sdk/*:shared=False" -s:a build_type=Release -s:a compiler.cppstd=17 --deployer-package "^&" --envs-generation false"
+	cmd /C "refreshenv && IF EXIST .\venv\Scripts\activate.bat call .\venv\Scripts\activate.bat && conan install --requires=viam-orbbec/0.0.1 -o:a "viam-cpp-sdk/*:shared=False" -s:a build_type=Release -s:a compiler.cppstd=17 --deployer-package "^&" --envs-generation false"
 else
 	test -f ./venv/bin/activate && . ./venv/bin/activate; \
 	conan install --requires=viam-orbbec/0.0.1 \

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This module provides access to the color and depth sensors and creates pointclou
 - **Darwin ARM64**
 - **Linux x64**: Ubuntu 24.04
 - **Linux ARM64**: NVIDIA Jetson AGX Orin, NVIDIA Jetson Orin NX, NVIDIA Jetson Orin Nano, NVIDIA Jetson AGX Xavier, NVIDIA Jetson Xavier NX
+- **Windows AMD64**: Windows 11
 
 ## Model viam:orbbec:astra2
 

--- a/bin/build.bat
+++ b/bin/build.bat
@@ -1,0 +1,2 @@
+set ORBBEC_SDK_DIR=%ORBBEC_SDK_DIR: =%
+Powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "& 'bin\build.ps1' exit $LASTEXITCODE"

--- a/bin/build.ps1
+++ b/bin/build.ps1
@@ -29,7 +29,7 @@ conan install . `
 conan build . `
       --output-folder=build-conan `
       --build=none `
-      -o:a "viam-cpp-sdk/*shared=False" `
+       -o:a "viam-cpp-sdk/*:shared=False" `
       -s:a build_type=Release `
       -s:a "&:build_type=RelWithDebInfo" `
       -s:a compiler.cppstd=17

--- a/bin/build.ps1
+++ b/bin/build.ps1
@@ -1,0 +1,35 @@
+$ErrorActionPreference = "Stop"
+
+# Ensure that things installed with choco are visible to us
+Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+refreshenv
+
+# remove any prior build
+Remove-Item -Recurse -Force build-conan -ErrorAction SilentlyContinue
+
+# Path to virtual environment activate script
+$venvActivate = ".\venv\Scripts\Activate.ps1"
+
+# Create or activate virtual environment
+if (-not (Test-Path $venvActivate)) {
+    Write-Host "Creating and activating virtual environment..."
+    python -m venv venv
+    & $venvActivate
+} else {
+    Write-Host "Activating virtual environment..."
+    & $venvActivate
+}
+
+conan install . `
+      --build=missing `
+      -o:a "viam-cpp-sdk/*:shared=False" `
+      -s:a build_type=Release `
+      -s:a compiler.cppstd=17
+
+conan build . `
+      --output-folder=build-conan `
+      --build=none `
+      -o:a "viam-cpp-sdk/*shared=False" `
+      -s:a build_type=Release `
+      -s:a "&:build_type=RelWithDebInfo" `
+      -s:a compiler.cppstd=17

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -1,3 +1,1 @@
-set ORBBEC_SDK_VERSION=%ORBBEC_SDK_VERSION: =%
-set ORBBEC_SDK_DIR=%ORBBEC_SDK_DIR: =%
 Powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "& 'bin\setup.ps1' exit $LASTEXITCODE"

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -1,0 +1,3 @@
+set ORBBEC_SDK_VERSION=%ORBBEC_SDK_VERSION: =%
+set ORBBEC_SDK_DIR=%ORBBEC_SDK_DIR: =%
+Powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "& 'bin\setup.ps1' exit $LASTEXITCODE"

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -1,0 +1,73 @@
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command choco.exe -ErrorAction SilentlyContinue)) {
+    Write-Host "Chocolatey is not installed. Please install Chocolatey from https://chocolatey.org/install"
+    exit 1
+}
+
+choco install -y cmake wget python311 unzip git
+
+# Ensure that things installed with choco are visible to us
+Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+refreshenv
+
+# Path to virtual environment activate script
+$venvActivate = ".\venv\Scripts\Activate.ps1"
+
+# Create or activate virtual environment
+if (-not (Test-Path $venvActivate)) {
+    Write-Host "Creating and activating virtual environment..."
+    python -m venv venv
+    & $venvActivate
+} else {
+    Write-Host "Activating virtual environment..."
+    & $venvActivate
+}
+
+# Set up Conan
+$conanExe = ".\venv\Scripts\conan.exe"
+if (-not (Test-Path $conanExe)) {
+    Write-Host "Installing Conan..."
+    python -m pip install conan
+} else {
+    Write-Host "Conan already installed."
+}
+
+# Initialize conan if it hasn't been already
+conan profile detect
+if (!$?) { Write-Host "Conan is already installed" }
+
+# Clone the C++ SDK repo
+mkdir tmp_cpp_sdk
+Push-Location tmp_cpp_sdk
+git clone https://github.com/viamrobotics/viam-cpp-sdk.git
+Push-Location viam-cpp-sdk
+
+# NOTE: If you change this version, also change it in the `conanfile.py` requirements
+# and in dockerfile
+git checkout releases/v0.16.0
+
+# Build the C++ SDK repo.
+#
+# We want a static binary, so we turn off shared. Elect for C++17
+# compilation, since it seems some of the dependencies we pick mandate
+# it anyway. Pin to the Windows 10 1809 associated windows SDK, and
+# opt for the static compiler runtime so we don't have a dependency on
+# the VC redistributable.
+#
+#  `-tf ""`, which disables the self test, this does not
+# work on windows
+
+# boost backtrace contains a unix only library dlfcn.h
+conan create . `
+      --build=missing `
+      -o:a "&:shared=False" `
+      -o:a "boost/*:with_stacktrace_backtrace=False" `
+      -o:a "boost/*:without_stacktrace=True" `
+      -s:a build_type=Release `
+      -s:a compiler.cppstd=17 `
+      -tf `"`"
+
+Pop-Location  # viam-cpp-sdk
+Pop-Location  # tmp_cpp_sdk
+Remove-Item -Recurse -Force tmp_cpp_sdk

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -55,9 +55,6 @@ git checkout releases/v0.16.0
 # opt for the static compiler runtime so we don't have a dependency on
 # the VC redistributable.
 #
-#  `-tf ""`, which disables the self test, this does not
-# work on windows
-
 # boost backtrace contains a unix only library dlfcn.h
 conan create . `
       --build=missing `
@@ -65,8 +62,7 @@ conan create . `
       -o:a "boost/*:with_stacktrace_backtrace=False" `
       -o:a "boost/*:without_stacktrace=True" `
       -s:a build_type=Release `
-      -s:a compiler.cppstd=17 `
-      -tf `"`"
+      -s:a compiler.cppstd=17
 
 Pop-Location  # viam-cpp-sdk
 Pop-Location  # tmp_cpp_sdk

--- a/src/cmake/fetch_orbbec.cmake
+++ b/src/cmake/fetch_orbbec.cmake
@@ -20,6 +20,12 @@ elseif (LINUX)
     else()
       message(FATAL_ERROR "Unsupported arch")
     endif()
+elseif (WIN32)
+  set(_ob_version "v2.4.8")
+  set(_ob_commit "ec8e346")
+  set(_ob_timestamp "202507032159")
+  set(_ob_suffix "win_x64")
+  set(_ob_sha256 "427f0f0596b5dcc229f10a78ad728da51e3065b599e2cc8737cbdedcc31f0aac")
 else()
     message(FATAL_ERROR "Unsupported platform")
 endif()
@@ -40,6 +46,16 @@ if(LINUX)
       ${CMAKE_CURRENT_BINARY_DIR}/_deps/orbbec-sdk-release-src/shared/99-obsensor-libusb.rules
       ${CMAKE_CURRENT_SOURCE_DIR}/99-obsensor-libusb.rules
     ONLY_IF_DIFFERENT
+  )
+elseif(WIN32)
+  # Copy dlls to the orbbecsdk lib folder
+  file(COPY
+  ${CMAKE_CURRENT_BINARY_DIR}/_deps/orbbec-sdk-release-src/bin/orbbecsdk.dll
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/_deps/orbbec-sdk-release-src/lib
+  )
+  file(COPY
+  ${CMAKE_CURRENT_BINARY_DIR}/_deps/orbbec-sdk-release-src/bin/extensions
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/_deps/orbbec-sdk-release-src/lib
   )
 endif()
 

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 #include "orbbec.hpp"
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 #include <math.h>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <iomanip>
 
 #include <iostream>
 #include <memory>
@@ -129,6 +133,14 @@ std::unordered_map<std::string, std::shared_ptr<ob::FrameSet>>& frame_set_by_ser
 
 // HELPERS BEGIN
 //
+
+// Convert integer to uppercase 4-digit hex string
+std::string intToHex(uint16_t value) {
+    std::stringstream ss;
+    ss << std::uppercase << std::hex << std::setw(4) << std::setfill('0') << value;
+    return ss.str();
+}
+
 uint64_t getNowUs() {
     return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
@@ -455,7 +467,7 @@ raw_camera_image encodeDepthRAW(const unsigned char* data, const uint64_t width,
 std::vector<std::string> Orbbec::validate(vsdk::ResourceConfig cfg) {
     auto attrs = cfg.attributes();
 
-    if (not attrs.count("serial_number")) {
+    if (!attrs.count("serial_number")) {
         throw std::invalid_argument("serial_number is a required argument");
     }
 
@@ -856,6 +868,100 @@ void registerDevice(std::string serialNumber, std::shared_ptr<ob::Device> dev) {
 
     pointCloudFilter->setCreatePointFormat(OB_FORMAT_RGB_POINT);
 
+#ifdef _WIN32
+    // On windows, we must add a metadata value to the windows device registry for the device to work correctly.
+    try {
+        const char* command = "powershell -Command \"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force\"";
+        int result = std::system(command);
+        if (result != 0) {
+            // command failed, try the backup
+            command = "powershell -Command \"Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -Force\"";
+            int result = std::system(command);
+            if (result != 0) {
+                VIAM_SDK_LOG(error) << "Could not set execution policy";
+            }
+        }
+
+        // Base registry paths
+        std::vector<std::string> searchTrees = {
+            // KSCATEGORY_CAPTURE class,used for video capture devices
+            "SYSTEM\\CurrentControlSet\\Control\\DeviceClasses\\{e5323777-f976-4f5b-9b55-b94699c46e44}",
+            // KSCATEGORY_RENDER class, used for rendering devices
+            "SYSTEM\\CurrentControlSet\\Control\\DeviceClasses\\{65E8773D-8F56-11D0-A3B9-00A0C9223196}"};
+
+        uint16_t vid = dev->getDeviceInfo()->vid();
+        uint16_t pid = dev->getDeviceInfo()->pid();
+        std::string baseDeviceId = "##?#USB#VID_" + intToHex(vid) + "&PID_" + intToHex(pid);
+
+        for (const auto& subtree : searchTrees) {
+            // Open the device registry key
+            HKEY hkey;
+            if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, subtree.c_str(), 0, KEY_ENUMERATE_SUB_KEYS, &hkey) != ERROR_SUCCESS) {
+                VIAM_SDK_LOG(error) << "Could not open device registry key: " << subtree;
+                continue;
+            }
+
+            char name[512];
+            DWORD nameSize;
+            DWORD index = 0;
+            while (true) {
+                // reset before each call
+                nameSize = sizeof(name);
+
+                // enumerate all of the keys in the devices folder we previously opened
+                LONG result = RegEnumKeyExA(hkey, index, name, &nameSize, NULL, NULL, NULL, NULL);
+                if (result == ERROR_NO_MORE_ITEMS) {
+                    break;  // normal end of enumeration
+                } else if (result != ERROR_SUCCESS) {
+                    VIAM_SDK_LOG(error) << "device registry key enumeration failed: " << result;
+                    break;
+                }
+                std::string subKeyName(name);
+                // find the enteries for our orbbec device.
+                if (subKeyName.find("USB#VID_" + intToHex(vid) + "&PID_" + intToHex(pid)) == std::string::npos) {
+                    // not a match for an orbbec device, go to next key
+                    ++index;
+                    continue;
+                }
+
+                std::string deviceParamsKey = subtree + "\\" + subKeyName + "\\#GLOBAL\\Device Parameters";
+                std::string valueName = "MetadataBufferSizeInKB0";
+                HKEY hDeviceKey;
+                // open the orbbec device parameters key
+                result = RegOpenKeyExA(HKEY_LOCAL_MACHINE, deviceParamsKey.c_str(), 0, KEY_READ | KEY_SET_VALUE, &hDeviceKey);
+                if (result != ERROR_SUCCESS) {
+                    VIAM_SDK_LOG(error) << "Couldn't open windows registry device parameters key: " << deviceParamsKey;
+                    ++index;
+                    continue;
+                }
+                // check if the metadata value already exists
+                DWORD data;
+                DWORD dataSize = sizeof(data);
+                result = RegQueryValueExA(hDeviceKey, valueName.c_str(), nullptr, nullptr, reinterpret_cast<BYTE*>(&data), &dataSize);
+                if (result == ERROR_FILE_NOT_FOUND) {
+                    // value does not exist yet, create it.
+                    DWORD value = 5;
+                    result =
+                        RegSetValueExA(hDeviceKey, valueName.c_str(), 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value));
+                    if (result != ERROR_SUCCESS) {
+                        VIAM_SDK_LOG(error) << "Couldn't set metadata registry value for key " << deviceParamsKey;
+                    } else {
+                        VIAM_SDK_LOG(info) << "Created value " << valueName << " = " << value << " for key " << deviceParamsKey;
+                    }
+                } else if (result == ERROR_SUCCESS) {
+                    VIAM_SDK_LOG(info) << "Value already exists on key " << deviceParamsKey << ", skipping.";
+                } else {
+                    VIAM_SDK_LOG(error) << "Error reading metadata value for key " << deviceParamsKey << ": " << result;
+                }
+                RegCloseKey(hDeviceKey);
+                ++index;
+            }
+            RegCloseKey(hkey);
+        }
+    } catch (const std::exception& e) {
+        throw std::runtime_error("failed to update windows device registry keys: " + std::string(e.what()));
+    }
+#endif
     {
         std::lock_guard<std::mutex> lock(devices_by_serial_mu());
         std::unique_ptr<ViamOBDevice> my_dev = std::make_unique<ViamOBDevice>();

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -135,7 +135,7 @@ std::unordered_map<std::string, std::shared_ptr<ob::FrameSet>>& frame_set_by_ser
 //
 
 // Convert integer to uppercase 4-digit hex string
-std::string intToHex(uint16_t value) {
+std::string uint16ToHex(uint16_t value) {
     std::stringstream ss;
     ss << std::uppercase << std::hex << std::setw(4) << std::setfill('0') << value;
     return ss.str();
@@ -870,6 +870,8 @@ void registerDevice(std::string serialNumber, std::shared_ptr<ob::Device> dev) {
 
 #ifdef _WIN32
     // On windows, we must add a metadata value to the windows device registry for the device to work correctly.
+    // Adapted from the orbbec SDK setup script:
+    // https://github.com/orbbec/OrbbecSDK_v2/blob/main/scripts/env_setup/obsensor_metadata_win10.ps1
     try {
         const char* command = "powershell -Command \"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force\"";
         int result = std::system(command);
@@ -891,7 +893,7 @@ void registerDevice(std::string serialNumber, std::shared_ptr<ob::Device> dev) {
 
         uint16_t vid = dev->getDeviceInfo()->vid();
         uint16_t pid = dev->getDeviceInfo()->pid();
-        std::string baseDeviceId = "##?#USB#VID_" + intToHex(vid) + "&PID_" + intToHex(pid);
+        std::string baseDeviceId = "##?#USB#VID_" + uint16ToHex(vid) + "&PID_" + uint16ToHex(pid);
 
         for (const auto& subtree : searchTrees) {
             // Open the device registry key
@@ -918,7 +920,7 @@ void registerDevice(std::string serialNumber, std::shared_ptr<ob::Device> dev) {
                 }
                 std::string subKeyName(name);
                 // find the enteries for our orbbec device.
-                if (subKeyName.find("USB#VID_" + intToHex(vid) + "&PID_" + intToHex(pid)) == std::string::npos) {
+                if (subKeyName.find("USB#VID_" + uint16ToHex(vid) + "&PID_" + uint16ToHex(pid)) == std::string::npos) {
                     // not a match for an orbbec device, go to next key
                     ++index;
                     continue;

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -150,7 +150,6 @@ void checkFirmwareVersion(const std::string version) {
     }
 }
 
-
 // Convert integer to uppercase 4-digit hex string
 std::string uint16ToHex(uint16_t value) {
     std::stringstream ss;


### PR DESCRIPTION
Adds orbbec windows AMD64 support. 

This adds a code change to add device keys to the windows registry, from orbbec SDK readme on why this is needed:
> For windows, you need to register the metadata associated with frames (this includes things like timestamps and other information about the video frame).
> Notes: If the metadata is not registered, the device timestamp will be abnormal, thereby affecting the SDK’s internal frame synchronization functionality."

