### PR TITLE
[RSDK-11713]         Update orbbec to implement new Images() API

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -55,7 +55,7 @@ fi
 
 # NOTE: If you change this version, also change it in the `conanfile.py` requirements
 # and in the Dockerfile
-git checkout releases/v0.16.0
+git checkout releases/v0.19.0
 
 # Build the C++ SDK repo
 #

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,7 +28,7 @@ class orbbec(ConanFile):
     def requirements(self):
         # NOTE: If you update the `viam-cpp-sdk` dependency here, it
         # should also be updated in `bin/setup.{sh,ps1}`.
-        self.requires("viam-cpp-sdk/0.16.0")
+        self.requires("viam-cpp-sdk/0.19.0")
         self.requires("openssl/3.3.2")
         self.requires("libcurl/8.9.1")
         self.requires("libzip/1.11.1")

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ class orbbec(ConanFile):
 
     def requirements(self):
         # NOTE: If you update the `viam-cpp-sdk` dependency here, it
-        # should also be updated in `bin/setup.{sh,ps1}`.
+        # should also be updated in `bin/setup.{sh,ps1}`, and in the Dockerfile.
         self.requires("viam-cpp-sdk/0.19.0")
         self.requires("openssl/3.3.2")
         self.requires("libcurl/8.9.1")

--- a/etc/Dockerfile.ubuntu.jammy
+++ b/etc/Dockerfile.ubuntu.jammy
@@ -48,7 +48,7 @@ RUN python3 -m pip install conan
 RUN conan profile detect
 
 RUN git clone https://github.com/viamrobotics/viam-cpp-sdk.git \
-    --branch releases/v0.16.0 --depth=1 && \
+    --branch releases/v0.19.0 --depth=1 && \
     cd viam-cpp-sdk && \
     conan create . \
     --build=missing \

--- a/etc/Dockerfile.ubuntu.jammy
+++ b/etc/Dockerfile.ubuntu.jammy
@@ -47,6 +47,8 @@ RUN python3 -m venv venv && . ./venv/bin/activate
 RUN python3 -m pip install conan
 RUN conan profile detect
 
+# NOTE: If you update the `viam-cpp-sdk` dependency here, it
+# should also be updated in `bin/setup.{sh,ps1}`, and in the conanfile.py.
 RUN git clone https://github.com/viamrobotics/viam-cpp-sdk.git \
     --branch releases/v0.19.0 --depth=1 && \
     cd viam-cpp-sdk && \
@@ -55,5 +57,3 @@ RUN git clone https://github.com/viamrobotics/viam-cpp-sdk.git \
     -o:a "&:shared=False" \
     -s:a build_type=Release \
     -s:a compiler.cppstd=17
-
-

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -953,7 +953,7 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
         }
 
         if (response.images.empty()) {
-            VIAM_SDK_LOG(warn) << "[get_images] no camera sources matched the filter";
+            VIAM_SDK_LOG(error) << "[get_images] error: no camera sources matched the filter";
             return response;
         }
 

--- a/src/module/orbbec.hpp
+++ b/src/module/orbbec.hpp
@@ -26,7 +26,7 @@ class Orbbec final : public viam::sdk::Camera, public viam::sdk::Reconfigurable 
     void reconfigure(const viam::sdk::Dependencies& deps, const viam::sdk::ResourceConfig& cfg) override;
     viam::sdk::ProtoStruct do_command(const viam::sdk::ProtoStruct& command) override;
     raw_image get_image(std::string mime_type, const viam::sdk::ProtoStruct& extra) override;
-    image_collection get_images() override;
+    image_collection get_images(std::vector<std::string> filter_source_names, const viam::sdk::ProtoStruct& extra) override;
     point_cloud get_point_cloud(std::string mime_type, const viam::sdk::ProtoStruct& extra) override;
     properties get_properties() override;
     std::vector<viam::sdk::GeometryConfig> get_geometries(const viam::sdk::ProtoStruct& extra) override;


### PR DESCRIPTION
[RSDK-11713](https://viam.atlassian.net/browse/RSDK-11713)


[RSDK-11713]: https://viam.atlassian.net/browse/RSDK-11713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Manual Tests

## Live stream with custom build `viam-server` using GetImages in stream server
<img width="1318" height="893" alt="Screenshot 2025-09-11 at 3 54 19 PM" src="https://github.com/user-attachments/assets/0e366193-2547-4e23-b703-1358cbfced4f" /> ✅

## Python Client specifying "color" filter
Got back good image and only 1 image (color no depth) ✅

## Python Client specifying "depth" filter
Got back good depth image and only 1 image (depth no color) ✅

## Python Client specifying no filter
Got back both images successfully ✅

## Python Client specifying empty filter `[]`
Got back both images successfully ✅
