### PR TITLE
Fix: Update CPP SDK version in windows build

### DIFF
--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -45,7 +45,7 @@ Push-Location viam-cpp-sdk
 
 # NOTE: If you change this version, also change it in the `conanfile.py` requirements
 # and in dockerfile
-git checkout releases/v0.16.0
+git checkout releases/v0.19.0
 
 # Build the C++ SDK repo.
 #


### PR DESCRIPTION
The windows build failed due to the PS script not matching up with the CPP SDK version that was updated [here](https://github.com/viam-modules/orbbec/commit/157ea8240910d4a152f430e3accf5f330a14277d). Updating it to match the conanfile.py.