### PR TITLE
[RSDK-11953] Fixing orbbec's get_images

### DIFF
--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -1362,10 +1362,6 @@ vsdk::ProtoStruct Orbbec::do_command(const vsdk::ProtoStruct& command) {
                 resp.emplace(firmware_key, std::string("firmware successfully updated, unplug and replug the device"));
 #endif
             }
-        } else if (kv.first == "get_images") {
-            VIAM_SDK_LOG(info) << "do_command get_images";
-            get_images({"color", "depth"}, viam::sdk::ProtoStruct{});
-            // resp.emplace("get_images", get_images({"color", "depth"}, viam::sdk::ProtoStruct{}).to_proto());
         }
     }
     return resp;

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -1124,12 +1124,12 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
             std::lock_guard<std::mutex> lock(frame_set_by_serial_mu());
             auto search = frame_set_by_serial().find(serial_number);
             if (search == frame_set_by_serial().end()) {
-                throw std::invalid_argument("no frame yet");
+                throw std::runtime_error("no frame yet");
             }
             fs = search->second;
         }
         if (fs == nullptr) {
-            throw std::invalid_argument("no frameset");
+            throw std::runtime_error("no frameset");
         }
 
         bool should_process_color = false;
@@ -1157,7 +1157,7 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
         {
             std::lock_guard<std::mutex> lock(config_by_serial_mu());
             if (config_by_serial().count(serial_number) == 0) {
-                throw std::invalid_argument("device with serial number " + serial_number + " is not in config_by_serial");
+                throw std::runtime_error("device with serial number " + serial_number + " is not in config_by_serial");
             }
             device_format_opt = config_by_serial().at(serial_number).device_format;
         }
@@ -1165,7 +1165,7 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
         if (should_process_color) {
             color = fs->getFrame(OB_FRAME_COLOR);
             if (color == nullptr) {
-                throw std::invalid_argument("no color frame");
+                throw std::runtime_error("no color frame");
             }
             if (supported_color_formats.count(ob::TypeHelper::convertOBFormatTypeToString(color->getFormat())) == 0) {
                 std::ostringstream buffer;
@@ -1176,14 +1176,14 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
                 }
 
                 VIAM_SDK_LOG(error) << buffer.str();
-                throw std::invalid_argument(buffer.str());
+                throw std::runtime_error(buffer.str());
             }
 
             uint64_t diff = timeSinceFrameUs(nowUs, color->getSystemTimeStampUs());
             if (diff > maxFrameAgeUs) {
                 std::ostringstream buffer;
                 buffer << "no recent color frame: check USB connection, diff: " << diff << "us";
-                throw std::invalid_argument(buffer.str());
+                throw std::runtime_error(buffer.str());
             }
 
             if (device_format_opt.has_value()) {
@@ -1192,7 +1192,7 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
                         std::ostringstream buffer;
                         buffer << "color format mismatch, expected " << device_format_opt->color_format.value() << " got "
                                << ob::TypeHelper::convertOBFormatTypeToString(color->getFormat());
-                        throw std::invalid_argument(buffer.str());
+                        throw std::runtime_error(buffer.str());
                     }
                 }
             } else {
@@ -1200,7 +1200,7 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
                     std::ostringstream buffer;
                     buffer << "color format mismatch, expected " << Orbbec::default_color_format << " got "
                            << ob::TypeHelper::convertOBFormatTypeToString(color->getFormat());
-                    throw std::invalid_argument(buffer.str());
+                    throw std::runtime_error(buffer.str());
                 }
             }
 
@@ -1224,14 +1224,14 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
                 std::ostringstream buffer;
                 buffer << "[get_images] unsupported color format: " << ob::TypeHelper::convertOBFormatTypeToString(color->getFormat());
                 VIAM_SDK_LOG(error) << buffer.str();
-                throw std::invalid_argument(buffer.str());
+                throw std::runtime_error(buffer.str());
             }
         }
 
         if (should_process_depth) {
             depth = fs->getFrame(OB_FRAME_DEPTH);
             if (depth == nullptr) {
-                throw std::invalid_argument("no depth frame");
+                throw std::runtime_error("no depth frame");
             }
             if (supported_depth_formats.count(ob::TypeHelper::convertOBFormatTypeToString(depth->getFormat())) == 0) {
                 std::ostringstream buffer;
@@ -1241,28 +1241,28 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
                     buffer << format << " ";
                 }
                 VIAM_SDK_LOG(error) << buffer.str();
-                throw std::invalid_argument(buffer.str());
+                throw std::runtime_error(buffer.str());
             }
 
             uint64_t diff = timeSinceFrameUs(nowUs, depth->getSystemTimeStampUs());
             if (diff > maxFrameAgeUs) {
                 std::ostringstream buffer;
                 buffer << "no recent depth frame: check USB connection, diff: " << diff << "us";
-                throw std::invalid_argument(buffer.str());
+                throw std::runtime_error(buffer.str());
             }
             if (device_format_opt->depth_format.has_value()) {
                 if (ob::TypeHelper::convertOBFormatTypeToString(depth->getFormat()) != device_format_opt->depth_format.value()) {
                     std::ostringstream buffer;
                     buffer << "depth format mismatch, expected " << device_format_opt->depth_format.value() << " got "
                            << ob::TypeHelper::convertOBFormatTypeToString(depth->getFormat());
-                    throw std::invalid_argument(buffer.str());
+                    throw std::runtime_error(buffer.str());
                 }
             } else {
                 if (ob::TypeHelper::convertOBFormatTypeToString(depth->getFormat()) != Orbbec::default_depth_format) {
                     std::ostringstream buffer;
                     buffer << "depth format mismatch, expected " << Orbbec::default_depth_format << " got "
                            << ob::TypeHelper::convertOBFormatTypeToString(depth->getFormat());
-                    throw std::invalid_argument(buffer.str());
+                    throw std::runtime_error(buffer.str());
                 }
             }
 


### PR DESCRIPTION
Currently get_images is failing as depth shared_pointer is null when we are calling it inside the should_process_color section, we need to call it from the should_process_depth instead, after depth has been populated.