### PR TITLE
[RSDK-12107] Disabling windows from build and publish flows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
             container:
               image: ghcr.io/viamrobotics/rdk-devenv:arm64
               options: --platform linux/arm64
-          - os: windows-latest
+          # - os: windows-latest
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,9 @@ jobs:
             container:
               image: ghcr.io/viam-modules/orbbec/viam-cpp-base-orin:0.0.1
             artifact-name: module-linux-arm64
-          - platform: windows/amd64
-            os: windows-latest
-            artifact-name: module-windows-amd64
+          # - platform: windows/amd64
+          #   os: windows-latest
+          #   artifact-name: module-windows-amd64
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}


### PR DESCRIPTION
Windows is failing to build, which is blocking our CI, disabling it for now until it is fixed.