### PR TITLE
use version range for openssl

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class orbbec(ConanFile):
         # NOTE: If you update the `viam-cpp-sdk` dependency here, it
         # should also be updated in `bin/setup.{sh,ps1}`, and in the Dockerfile.
         self.requires("viam-cpp-sdk/0.19.0")
-        self.requires("openssl/3.3.2")
+        self.requires("openssl/[>=3 <4]")
         self.requires("libcurl/8.9.1")
         self.requires("libzip/1.11.1")
         self.requires("libpng/1.6.50")


### PR DESCRIPTION
our CI is taking even longer than usual because the explicitly specified version of openSSL conflicts with the one that we get from gRPC, so we are rebuilding a bunch of those dependencies even though we just built them in the previous step. 

since we don't really care about an exact version, just specify a version range instead