### PR TITLE
[RSDK-12899] Fix set device properties

### DIFF
--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -297,7 +297,6 @@ viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
             }
         }
     }
-    return getDeviceProperties(device, command, writable_properties);
 }
 
 template <typename DeviceT>

--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -301,7 +301,7 @@ viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
             }
         }
     }
-    return getDeviceProperties<DeviceT>(device, command, {});
+    return getDeviceProperties(device, command, writable_properties);
 }
 
 template <typename DeviceT>

--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <system_error>
 #include <viam/sdk/common/proto_value.hpp>
 
 namespace device_control {
@@ -243,6 +244,15 @@ viam::sdk::ProtoStruct getDeviceProperties(std::shared_ptr<DeviceT> device,
     return properties;
 }
 
+// Helper struct to hold validated property information for two-phase set
+struct ValidatedProperty {
+    OBPropertyItem item;
+    int int_value;
+    double float_value;
+    bool bool_value;
+    enum class Type { INT, FLOAT, BOOL } value_type;
+};
+
 template <typename DeviceT>
 viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
                                            const viam::sdk::ProtoValue& properties,
@@ -257,53 +267,133 @@ viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
         ss << "calling " << command << " on non-struct properties";
         return {{"error", ss.str()}};
     }
-    std::unordered_set<std::string> writable_properties;
+
     auto const& properties_map = properties.template get_unchecked<viam::sdk::ProtoStruct>();
+
+    // Build a map of device properties for quick lookup
+    std::unordered_map<std::string, OBPropertyItem> device_properties;
     int const supportedPropertyCount = device->getSupportedPropertyCount();
     for (int i = 0; i < supportedPropertyCount; i++) {
         OBPropertyItem property_item = device->getSupportedProperty(i);
-        if (properties_map.count(property_item.name) > 0) {
-            if (property_item.permission == OB_PERMISSION_DENY || property_item.permission == OB_PERMISSION_READ) {
+        device_properties[property_item.name] = property_item;
+    }
+
+    // Phase 1: Validate all properties before setting any
+    std::vector<ValidatedProperty> validated_properties;
+    std::unordered_set<std::string> writable_properties;
+
+    for (auto const& [prop_name, prop_value] : properties_map) {
+        // Check if property exists on the device
+        auto it = device_properties.find(prop_name);
+        if (it == device_properties.end()) {
+            std::stringstream error_ss;
+            error_ss << "Property '" << prop_name << "' is not supported by this device.";
+            VIAM_SDK_LOG(error) << error_ss.str();
+            return {{"error", error_ss.str()}};
+        }
+
+        OBPropertyItem const& property_item = it->second;
+
+        // Check if the property is writable
+        if (property_item.permission == OB_PERMISSION_DENY || property_item.permission == OB_PERMISSION_READ) {
+            std::stringstream error_ss;
+            error_ss << "Property '" << prop_name << "' is not writable (permission: " << permissionToString(property_item.permission)
+                     << ").";
+            VIAM_SDK_LOG(error) << error_ss.str();
+            return {{"error", error_ss.str()}};
+        }
+
+        // Validate value structure
+        auto const value_struct_opt = prop_value.template get<viam::sdk::ProtoStruct>();
+        if (!value_struct_opt) {
+            std::stringstream error_ss;
+            error_ss << "Value for property '" << prop_name << "' must be a struct with a 'current' field.";
+            VIAM_SDK_LOG(error) << error_ss.str();
+            return {{"error", error_ss.str()}};
+        }
+
+        auto const& value_struct = *value_struct_opt;
+        if (value_struct.count("current") == 0) {
+            std::stringstream error_ss;
+            error_ss << "Value for property '" << prop_name << "' is missing required 'current' field.";
+            VIAM_SDK_LOG(error) << error_ss.str();
+            return {{"error", error_ss.str()}};
+        }
+
+        auto const& value = value_struct.at("current");
+
+        // Validate type compatibility and extract value
+        ValidatedProperty validated;
+        validated.item = property_item;
+
+        if (property_item.type == OB_INT_PROPERTY) {
+            if (!value.template is_a<double>()) {
                 std::stringstream error_ss;
-                error_ss << "Property " << property_item.name << " is not writable.";
-                VIAM_SDK_LOG(warn) << error_ss.str();
-                return {{"error", error_ss.str()}};
-            }
-            try {
-                auto const& value_struct = properties_map.at(property_item.name).get<viam::sdk::ProtoStruct>();
-                if (!value_struct) {
-                    std::stringstream error_ss;
-                    error_ss << "Value for property " << property_item.name << " is not a struct, skipping.";
-                    VIAM_SDK_LOG(warn) << error_ss.str();
-                    continue;
-                }
-                auto const& value = value_struct->at("current");
-                writable_properties.insert(property_item.name);
-                if (property_item.type == OB_INT_PROPERTY && value.is_a<double>()) {
-                    int int_value = static_cast<int>(value.get_unchecked<double>());
-                    device->setIntProperty(property_item.id, int_value);
-                    VIAM_SDK_LOG(info) << "[setDeviceProperties] Set int property " << property_item.name << " to " << int_value;
-                } else if (property_item.type == OB_FLOAT_PROPERTY && value.is_a<double>()) {
-                    double float_value = value.get_unchecked<double>();
-                    device->setFloatProperty(property_item.id, float_value);
-                    VIAM_SDK_LOG(info) << "[setDeviceProperties] Set float property " << property_item.name << " to " << float_value;
-                } else if (property_item.type == OB_BOOL_PROPERTY && value.is_a<bool>()) {
-                    bool bool_value = value.get_unchecked<bool>();
-                    device->setBoolProperty(property_item.id, bool_value);
-                    VIAM_SDK_LOG(info) << "[setDeviceProperties] Set bool property " << property_item.name << " to "
-                                       << (bool_value ? "true" : "false");
-                } else {
-                    VIAM_SDK_LOG(warn) << "[setDeviceProperties] Type mismatch or unsupported type for property " << property_item.name
-                                       << ", skipping.";
-                }
-            } catch (ob::Error& e) {
-                std::stringstream error_ss;
-                error_ss << "Failed to set property " << property_item.name << ": " << e.what();
+                error_ss << "Property '" << prop_name << "' expects numeric value for int property.";
                 VIAM_SDK_LOG(error) << error_ss.str();
                 return {{"error", error_ss.str()}};
             }
+            validated.int_value = static_cast<int>(value.template get_unchecked<double>());
+            validated.value_type = ValidatedProperty::Type::INT;
+        } else if (property_item.type == OB_FLOAT_PROPERTY) {
+            if (!value.template is_a<double>()) {
+                std::stringstream error_ss;
+                error_ss << "Property '" << prop_name << "' expects numeric value for float property.";
+                VIAM_SDK_LOG(error) << error_ss.str();
+                return {{"error", error_ss.str()}};
+            }
+            validated.float_value = value.template get_unchecked<double>();
+            validated.value_type = ValidatedProperty::Type::FLOAT;
+        } else if (property_item.type == OB_BOOL_PROPERTY) {
+            if (!value.template is_a<bool>()) {
+                std::stringstream error_ss;
+                error_ss << "Property '" << prop_name << "' expects boolean value for bool property.";
+                VIAM_SDK_LOG(error) << error_ss.str();
+                return {{"error", error_ss.str()}};
+            }
+            validated.bool_value = value.template get_unchecked<bool>();
+            validated.value_type = ValidatedProperty::Type::BOOL;
+        } else {
+            std::stringstream error_ss;
+            error_ss << "Property '" << prop_name << "' has unsupported type: " << propertyTypeToString(property_item.type) << ".";
+            VIAM_SDK_LOG(error) << error_ss.str();
+            return {{"error", error_ss.str()}};
+        }
+
+        validated_properties.push_back(validated);
+        writable_properties.insert(prop_name);
+    }
+
+    // Phase 2: Apply all validated properties
+    for (auto const& validated : validated_properties) {
+        try {
+            switch (validated.value_type) {
+                case ValidatedProperty::Type::INT:
+                    device->setIntProperty(validated.item.id, validated.int_value);
+                    VIAM_SDK_LOG(info) << "[setDeviceProperties] Set int property " << validated.item.name << " to " << validated.int_value;
+                    break;
+                case ValidatedProperty::Type::FLOAT:
+                    device->setFloatProperty(validated.item.id, validated.float_value);
+                    VIAM_SDK_LOG(info) << "[setDeviceProperties] Set float property " << validated.item.name << " to "
+                                       << validated.float_value;
+                    break;
+                case ValidatedProperty::Type::BOOL:
+                    device->setBoolProperty(validated.item.id, validated.bool_value);
+                    VIAM_SDK_LOG(info) << "[setDeviceProperties] Set bool property " << validated.item.name << " to "
+                                       << (validated.bool_value ? "true" : "false");
+                    break;
+            }
+        } catch (ob::Error& e) {
+            // Note: At this point we may have partially applied properties.
+            // This is unavoidable since the SDK doesn't support transactions.
+            std::stringstream error_ss;
+            error_ss << "Failed to set property '" << validated.item.name << "': " << e.what()
+                     << " (some properties may have been partially applied)";
+            VIAM_SDK_LOG(error) << error_ss.str();
+            return {{"error", error_ss.str()}};
         }
     }
+
     return getDeviceProperties(device, command, writable_properties);
 }
 

--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -247,6 +247,9 @@ template <typename DeviceT>
 viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
                                            const viam::sdk::ProtoValue& properties,
                                            std::string const& command) {
+    if (device == nullptr) {
+        return {{"error", "device is null"}};
+    }
     if (!properties.template is_a<viam::sdk::ProtoStruct>()) {
         return {{"error", "properties must be a struct"}};
     }
@@ -269,6 +272,7 @@ viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
                     std::stringstream error_ss;
                     error_ss << "Value for property " << property_item.name << " is not a struct, skipping.";
                     VIAM_SDK_LOG(warn) << error_ss.str();
+                    continue;
                 }
                 auto const& value = value_struct->at("current");
                 writable_properties.insert(property_item.name);
@@ -297,6 +301,7 @@ viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
             }
         }
     }
+    return getDeviceProperties<DeviceT>(device, command, {});
 }
 
 template <typename DeviceT>

--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -248,10 +248,14 @@ viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
                                            const viam::sdk::ProtoValue& properties,
                                            std::string const& command) {
     if (device == nullptr) {
-        return {{"error", "device is null"}};
+        std::stringstream ss;
+        ss << "calling " << command << " on null device";
+        return {{"error", ss.str()}};
     }
     if (!properties.template is_a<viam::sdk::ProtoStruct>()) {
-        return {{"error", "properties must be a struct"}};
+        std::stringstream ss;
+        ss << "calling " << command << " on non-struct properties";
+        return {{"error", ss.str()}};
     }
     std::unordered_set<std::string> writable_properties;
     auto const& properties_map = properties.template get_unchecked<viam::sdk::ProtoStruct>();

--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -265,10 +265,9 @@ viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
         if (properties_map.count(property_item.name) > 0) {
             if (property_item.permission == OB_PERMISSION_DENY || property_item.permission == OB_PERMISSION_READ) {
                 std::stringstream error_ss;
-                error_ss << "Property " << property_item.name << " is not writable, skipping.";
+                error_ss << "Property " << property_item.name << " is not writable.";
                 VIAM_SDK_LOG(warn) << error_ss.str();
                 return {{"error", error_ss.str()}};
-                continue;
             }
             try {
                 auto const& value_struct = properties_map.at(property_item.name).get<viam::sdk::ProtoStruct>();

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -1454,7 +1454,8 @@ vsdk::ProtoStruct Orbbec::do_command(const vsdk::ProtoStruct& command) {
                 } else if (key == "get_device_properties") {
                     return device_control::getDeviceProperties(dev->device, key);
                 } else if (key == "set_device_properties") {
-                    return device_control::setDeviceProperties(dev->device, value, key);
+                    device_control::setDeviceProperties(dev->device, value, key);
+                    call_get_properties = true;
                 } else if (key == "get_device_property") {
                     return device_control::getDeviceProperty(dev->device, value, key);
                 } else if (key == "set_device_property") {

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -1418,6 +1418,7 @@ vsdk::ProtoStruct Orbbec::do_command(const vsdk::ProtoStruct& command) {
 
             std::unique_ptr<ViamOBDevice>& dev = search->second;
             for (auto const& [key, value] : command) {
+                VIAM_RESOURCE_LOG(info) << "Received command: " << key;
                 if (key == firmware_key) {
                     VIAM_RESOURCE_LOG(info) << "Received firmware update command";
                     vsdk::ProtoStruct resp = viam::sdk::ProtoStruct{};
@@ -1483,10 +1484,10 @@ vsdk::ProtoStruct Orbbec::do_command(const vsdk::ProtoStruct& command) {
                 } else if (key == "set_depth_unit") {
                     return device_control::setDepthUnit(dev->device, value, key);
                 } else if (key == "get_device_properties") {
+                    VIAM_RESOURCE_LOG(info) << "Received get_device_properties command";
                     return device_control::getDeviceProperties(dev->device, key);
                 } else if (key == "set_device_properties") {
-                    device_control::setDeviceProperties(dev->device, value, key);
-                    call_get_properties = true;
+                    return device_control::setDeviceProperties(dev->device, value, key);
                 } else if (key == "get_device_property") {
                     return device_control::getDeviceProperty(dev->device, value, key);
                 } else if (key == "set_device_property") {

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -1485,7 +1485,8 @@ vsdk::ProtoStruct Orbbec::do_command(const vsdk::ProtoStruct& command) {
                 } else if (key == "get_device_properties") {
                     return device_control::getDeviceProperties(dev->device, key);
                 } else if (key == "set_device_properties") {
-                    return device_control::setDeviceProperties(dev->device, value, key);
+                    device_control::setDeviceProperties(dev->device, value, key);
+                    call_get_properties = true;
                 } else if (key == "get_device_property") {
                     return device_control::getDeviceProperty(dev->device, value, key);
                 } else if (key == "set_device_property") {

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -1418,7 +1418,6 @@ vsdk::ProtoStruct Orbbec::do_command(const vsdk::ProtoStruct& command) {
 
             std::unique_ptr<ViamOBDevice>& dev = search->second;
             for (auto const& [key, value] : command) {
-                VIAM_RESOURCE_LOG(info) << "Received command: " << key;
                 if (key == firmware_key) {
                     VIAM_RESOURCE_LOG(info) << "Received firmware update command";
                     vsdk::ProtoStruct resp = viam::sdk::ProtoStruct{};
@@ -1484,7 +1483,6 @@ vsdk::ProtoStruct Orbbec::do_command(const vsdk::ProtoStruct& command) {
                 } else if (key == "set_depth_unit") {
                     return device_control::setDepthUnit(dev->device, value, key);
                 } else if (key == "get_device_properties") {
-                    VIAM_RESOURCE_LOG(info) << "Received get_device_properties command";
                     return device_control::getDeviceProperties(dev->device, key);
                 } else if (key == "set_device_properties") {
                     return device_control::setDeviceProperties(dev->device, value, key);


### PR DESCRIPTION
This PR fixes a crash on the `get_device_properties` `do_command`, caused by a missing continue statement on `get_device_properties` handling. 

This issue happens when the user calls `get_device_properties` with a non-struct payload, such as this:
```
{
  "set_device_properties": ""
}
```

With this fix, these kind of calls are correctly handled producing the following error
```
{
  "error": "calling set_device_properties on non-struct properties"
}
```

We are also checking that all settings being modified can actually be modified before doing it

This works OK:
```
{
  "set_device_properties":   
  {"OB_PROP_DEPTH_NOISE_REMOVAL_FILTER_MAX_SPECKLE_SIZE_INT": {
    "name": "OB_PROP_DEPTH_NOISE_REMOVAL_FILTER_MAX_SPECKLE_SIZE_INT",
    "type": "int",
    "max": 1000,
    "current": 1000,
    "id": 41,
    "default": 1000,
    "min": 1,
    "permission": "read_write"
  },
  "OB_PROP_DEPTH_ALIGN_HARDWARE_MODE_INT": {
    "current": 2,
    "min": 0,
    "max": 5,
    "permission": "read_write",
    "default": 0,
    "name": "OB_PROP_DEPTH_ALIGN_HARDWARE_MODE_INT",
    "id": 63,
    "type": "int"
  }
  }
```

This does not (missing `current` field), no fields are modified
```
{
  "set_device_properties":   
  {"OB_PROP_DEPTH_NOISE_REMOVAL_FILTER_MAX_SPECKLE_SIZE_INT": {
    "name": "OB_PROP_DEPTH_NOISE_REMOVAL_FILTER_MAX_SPECKLE_SIZE_INT",
    "type": "int",
    "max": 1000,    "id": 41,
    "default": 1000,
    "min": 1,
    "permission": "read_write"
  },
  "OB_PROP_DEPTH_ALIGN_HARDWARE_MODE_INT": {
    "current": 5,
    "min": 0,
    "max": 5,
    "permission": "read_write",
    "default": 0,
    "name": "OB_PROP_DEPTH_ALIGN_HARDWARE_MODE_INT",
    "id": 63,
    "type": "int"
  }
  }
}
```