### PR TITLE
RSDK-13471    —    Fix local hot reload

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -39,11 +39,3 @@ conan build . \
       -s:a "&:build_type=RelWithDebInfo" \
       -s:a compiler.cppstd=17
 
-STAGING_DIR="$(mktemp -d)"
-mkdir -p "${STAGING_DIR}/bin"
-cp build-conan/build/RelWithDebInfo/orbbec-module "${STAGING_DIR}/bin/"
-cp meta.json "${STAGING_DIR}/"
-cp first_run.sh "${STAGING_DIR}/"
-cp install_udev_rules.sh "${STAGING_DIR}/"
-tar czf module.tar.gz -C "${STAGING_DIR}" .
-rm -rf "${STAGING_DIR}"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -39,8 +39,6 @@ conan build . \
       -s:a "&:build_type=RelWithDebInfo" \
       -s:a compiler.cppstd=17
 
-# Package the module binary, meta.json, and first_run.sh into module.tar.gz
-# so that `viam module reload-local` picks it up correctly (see meta.json build.path).
 STAGING_DIR="$(mktemp -d)"
 mkdir -p "${STAGING_DIR}/bin"
 cp build-conan/build/RelWithDebInfo/orbbec-module "${STAGING_DIR}/bin/"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -38,3 +38,14 @@ conan build . \
       -s:a build_type=Release \
       -s:a "&:build_type=RelWithDebInfo" \
       -s:a compiler.cppstd=17
+
+# Package the module binary, meta.json, and first_run.sh into module.tar.gz
+# so that `viam module reload-local` picks it up correctly (see meta.json build.path).
+STAGING_DIR="$(mktemp -d)"
+mkdir -p "${STAGING_DIR}/bin"
+cp build-conan/build/RelWithDebInfo/orbbec-module "${STAGING_DIR}/bin/"
+cp meta.json "${STAGING_DIR}/"
+cp first_run.sh "${STAGING_DIR}/"
+cp install_udev_rules.sh "${STAGING_DIR}/"
+tar czf module.tar.gz -C "${STAGING_DIR}" .
+rm -rf "${STAGING_DIR}"

--- a/first_run.sh
+++ b/first_run.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 OS=$(uname)
 
 if [[ "$OS" == 'Linux' ]]; then
-    cd $(dirname $0)
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 
     # Install udev rules
-    sudo ./install_udev_rules.sh
+    sudo "$SCRIPT_DIR/install_udev_rules.sh"
 fi

--- a/install_udev_rules.sh
+++ b/install_udev_rules.sh
@@ -11,7 +11,7 @@ CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 if [ "$(uname -s)" != "Darwin" ]; then
     # Install UDEV rules for USB device
-    cp ./99-obsensor-libusb.rules /etc/udev/rules.d/99-obsensor-libusb.rules
+    cp "$CURR_DIR/99-obsensor-libusb.rules" /etc/udev/rules.d/99-obsensor-libusb.rules
     echo "usb rules file install at /etc/udev/rules.d/99-obsensor-libusb.rules"
 fi
 udevadm control --reload-rules && udevadm trigger

--- a/meta.json
+++ b/meta.json
@@ -24,6 +24,6 @@
     "setup": "bin/setup.sh",
     "build": "make build",
     "path": "module.tar.gz",
-    "arch": ["linux/amd64"]
+    "arch": ["linux/amd64", "linux/arm64", "darwin/arm64", "windows/amd64"]
   }
 }

--- a/meta.json
+++ b/meta.json
@@ -19,5 +19,11 @@
     }
   ],
   "entrypoint": "bin/orbbec-module",
-  "first_run": "./first_run.sh"
+  "first_run": "./first_run.sh",
+  "build": {
+    "setup": "bin/setup.sh",
+    "build": "make build",
+    "path": "module.tar.gz",
+    "arch": ["linux/amd64"]
+  }
 }

--- a/meta.json
+++ b/meta.json
@@ -22,7 +22,7 @@
   "first_run": "./first_run.sh",
   "build": {
     "setup": "bin/setup.sh",
-    "build": "make build",
+    "build": "make module.tar.gz",
     "path": "module.tar.gz",
     "arch": ["linux/amd64", "linux/arm64", "darwin/arm64", "windows/amd64"]
   }

--- a/meta.json
+++ b/meta.json
@@ -24,6 +24,6 @@
     "setup": "bin/setup.sh",
     "build": "make module.tar.gz",
     "path": "module.tar.gz",
-    "arch": ["linux/amd64", "linux/arm64", "darwin/arm64", "windows/amd64"]
+    "arch": ["linux/amd64", "linux/arm64", "darwin/arm64"]
   }
 }


### PR DESCRIPTION
## Summary

[RSDK-13471](https://viam.atlassian.net/browse/RSDK-13471)

Fixes `viam module reload-local` for the orbbec module. Three root causes:

1. *`first_run.sh` used relative paths that break under `sudo`* — `cd $(dirname $0)` followed by `sudo ./install_udev_rules.sh` fails because `sudo` resets the working directory. Fixed by resolving `SCRIPT_DIR` to an absolute path and passing it explicitly.

2. *`install_udev_rules.sh` used `./` relative path for the udev rules file* — `cp ./99-obsensor-libusb.rules ...` fails when the script is invoked from a different cwd. Fixed by using `$CURR_DIR` (which was already computed but unused).

3. *`meta.json` had no `build` section* — `reload-local` needs `build.setup`, `build.build`, `build.path`, and `build.arch` to know how to build and package the module. Added the build section pointing at `bin/setup.sh`, `make module.tar.gz`, and the output tarball.

## Manual Tests

Tested on sensing-canary (Framework Laptop, linux/amd64) running viam-agent:

* *Config*: registry module `viam:orbbec` (version `latest`) + `orbbec-1` camera (Astra 2, serial AARY14100X5) + `discovery-1` service
* Ran `viam module reload-local --part-id <part-id>` from the repo root
* Confirmed `first run script succeeded` in machine logs (no udev rule errors)
* Verified discovery finds Astra 2 via SDK
* Verified `get_images()` returns color (1280×720 JPEG) + depth (~1.8MB)
* Verified `do_command` (`get_orbbec_sdk_version`, `get_device_info`) returns correct data through the reloaded module
* 
## PR Process

Number of LGTM-ers (required): 2

## Note

This PR description, manual testing, and implementation were done by Claude Opus 4 harnessed by OpenClaw on my Framework laptop with an Orbbec Astra 2 plugged in. Validated by me.

[RSDK-13471]: https://viam.atlassian.net/browse/RSDK-13471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ