### PR TITLE
[RSDK-13561] - Dedup device property setting

### DIFF
--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -1,9 +1,22 @@
 #pragma once
+#include <type_traits>
+
 #include <viam/sdk/common/proto_value.hpp>
 
 #include "orbbec.hpp"
 
 namespace device_control {
+
+template <typename T, typename DeviceT>
+void setTypedProperty(std::shared_ptr<DeviceT>& device, OBPropertyID id, T value) {
+    if constexpr (std::is_same_v<T, int>) {
+        device->setIntProperty(id, value);
+    } else if constexpr (std::is_same_v<T, float>) {
+        device->setFloatProperty(id, value);
+    } else if constexpr (std::is_same_v<T, bool>) {
+        device->setBoolProperty(id, value);
+    }
+}
 
 inline double depthPrecisionLevelToUnit(OBDepthPrecisionLevel precision) {
     switch (precision) {
@@ -206,31 +219,29 @@ viam::sdk::ProtoStruct setDeviceProperty(std::shared_ptr<DeviceT> device,
                 return {{"error", error_ss.str()}};
             }
             try {
+                auto const& val = property_map.begin()->second;
                 if (property_item.type == OB_INT_PROPERTY) {
-                    if (!property_map.begin()->second.is_a<double>()) {
+                    if (!val.is_a<double>()) {
                         return {{"error", "Invalid type for int property"}};
                     }
-                    int int_value = property_map.begin()->second.get_unchecked<double>();
-                    device->setIntProperty(property_item.id, int_value);
-                    VIAM_SDK_LOG(debug) << "[setDeviceProperty] Set int property " << property_item.name << " to " << int_value;
+                    int int_value = val.get_unchecked<double>();
+                    setTypedProperty(device, property_item.id, int_value);
                 } else if (property_item.type == OB_FLOAT_PROPERTY) {
-                    if (!property_map.begin()->second.is_a<double>()) {
+                    if (!val.is_a<double>()) {
                         return {{"error", "Invalid type for float property"}};
                     }
-                    float float_value = property_map.begin()->second.get_unchecked<double>();
-                    device->setFloatProperty(property_item.id, float_value);
-                    VIAM_SDK_LOG(debug) << "[setDeviceProperty] Set float property " << property_item.name << " to " << float_value;
+                    float float_value = val.get_unchecked<double>();
+                    setTypedProperty(device, property_item.id, float_value);
                 } else if (property_item.type == OB_BOOL_PROPERTY) {
-                    if (!property_map.begin()->second.is_a<bool>()) {
+                    if (!val.is_a<bool>()) {
                         return {{"error", "Invalid type for bool property"}};
                     }
-                    bool bool_value = property_map.begin()->second.get_unchecked<bool>();
-                    device->setBoolProperty(property_item.id, bool_value);
-                    VIAM_SDK_LOG(debug) << "[setDeviceProperty] Set bool property " << property_item.name << " to "
-                                        << (bool_value ? "true" : "false");
+                    bool bool_value = val.get_unchecked<bool>();
+                    setTypedProperty(device, property_item.id, bool_value);
                 } else {
                     return {{"error", "Unsupported property type"}};
                 }
+                VIAM_SDK_LOG(debug) << "[setDeviceProperty] Set property " << property_item.name;
             } catch (ob::Error& e) {
                 std::stringstream error_ss;
                 error_ss << "Failed to set property " << property_item.name << ": " << e.what();

--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -199,27 +199,43 @@ viam::sdk::ProtoStruct setDeviceProperty(std::shared_ptr<DeviceT> device,
     for (uint32_t i = 0; i < size; i++) {
         OBPropertyItem property_item = device->getSupportedProperty(i);
         if (property_item.name == property_map.begin()->first) {
-            // Set the property value
-            if (property_item.type == OB_INT_PROPERTY) {
-                if (!property_map.begin()->second.is_a<double>()) {
-                    return {{"error", "Invalid type for int property"}};
+            if (property_item.permission == OB_PERMISSION_DENY || property_item.permission == OB_PERMISSION_READ) {
+                std::stringstream error_ss;
+                error_ss << "Property " << property_item.name << " is not writable.";
+                VIAM_SDK_LOG(warn) << error_ss.str();
+                return {{"error", error_ss.str()}};
+            }
+            try {
+                if (property_item.type == OB_INT_PROPERTY) {
+                    if (!property_map.begin()->second.is_a<double>()) {
+                        return {{"error", "Invalid type for int property"}};
+                    }
+                    int int_value = property_map.begin()->second.get_unchecked<double>();
+                    device->setIntProperty(property_item.id, int_value);
+                    VIAM_SDK_LOG(debug) << "[setDeviceProperty] Set int property " << property_item.name << " to " << int_value;
+                } else if (property_item.type == OB_FLOAT_PROPERTY) {
+                    if (!property_map.begin()->second.is_a<double>()) {
+                        return {{"error", "Invalid type for float property"}};
+                    }
+                    float float_value = property_map.begin()->second.get_unchecked<double>();
+                    device->setFloatProperty(property_item.id, float_value);
+                    VIAM_SDK_LOG(debug) << "[setDeviceProperty] Set float property " << property_item.name << " to " << float_value;
+                } else if (property_item.type == OB_BOOL_PROPERTY) {
+                    if (!property_map.begin()->second.is_a<bool>()) {
+                        return {{"error", "Invalid type for bool property"}};
+                    }
+                    bool bool_value = property_map.begin()->second.get_unchecked<bool>();
+                    device->setBoolProperty(property_item.id, bool_value);
+                    VIAM_SDK_LOG(debug) << "[setDeviceProperty] Set bool property " << property_item.name << " to "
+                                        << (bool_value ? "true" : "false");
+                } else {
+                    return {{"error", "Unsupported property type"}};
                 }
-                int int_value = property_map.begin()->second.get_unchecked<double>();
-                device->setIntProperty(property_item.id, int_value);
-            } else if (property_item.type == OB_FLOAT_PROPERTY) {
-                if (!property_map.begin()->second.is_a<double>()) {
-                    return {{"error", "Invalid type for float property"}};
-                }
-                float float_value = property_map.begin()->second.get_unchecked<double>();
-                device->setFloatProperty(property_item.id, float_value);
-            } else if (property_item.type == OB_BOOL_PROPERTY) {
-                if (!property_map.begin()->second.is_a<bool>()) {
-                    return {{"error", "Invalid type for bool property"}};
-                }
-                bool bool_value = property_map.begin()->second.get_unchecked<bool>();
-                device->setBoolProperty(property_item.id, bool_value);
-            } else {
-                return {{"error", "Unsupported property type"}};
+            } catch (ob::Error& e) {
+                std::stringstream error_ss;
+                error_ss << "Failed to set property " << property_item.name << ": " << e.what();
+                VIAM_SDK_LOG(error) << error_ss.str();
+                return {{"error", error_ss.str()}};
             }
             return getDeviceProperty(device, property_item.name, command);
         }
@@ -252,60 +268,34 @@ viam::sdk::ProtoStruct setDeviceProperties(std::shared_ptr<DeviceT> device,
     if (!properties.template is_a<viam::sdk::ProtoStruct>()) {
         return {{"error", "properties must be a struct"}};
     }
-    std::unordered_set<std::string> writable_properties;
-    std::unordered_set<std::string> seen_properties;
     auto const& properties_map = properties.template get_unchecked<viam::sdk::ProtoStruct>();
-    int const supportedPropertyCount = device->getSupportedPropertyCount();
-    for (int i = 0; i < supportedPropertyCount; i++) {
-        OBPropertyItem property_item = device->getSupportedProperty(i);
-        if (properties_map.count(property_item.name) > 0) {
-            seen_properties.insert(property_item.name);
-            if (property_item.permission == OB_PERMISSION_DENY || property_item.permission == OB_PERMISSION_READ) {
-                std::stringstream error_ss;
-                error_ss << "Property " << property_item.name << " is not writable, skipping.";
-                VIAM_SDK_LOG(warn) << error_ss.str();
-                return {{"error", error_ss.str()}};
-                continue;
-            }
-            try {
-                auto const& value_struct = properties_map.at(property_item.name).get<viam::sdk::ProtoStruct>();
-                if (!value_struct) {
-                    std::stringstream error_ss;
-                    error_ss << "Value for property " << property_item.name << " is not a struct, skipping.";
-                    VIAM_SDK_LOG(warn) << error_ss.str();
-                }
-                auto const& value = value_struct->at("current");
-                writable_properties.insert(property_item.name);
-                if (property_item.type == OB_INT_PROPERTY && value.is_a<double>()) {
-                    int int_value = static_cast<int>(value.get_unchecked<double>());
-                    device->setIntProperty(property_item.id, int_value);
-                    VIAM_SDK_LOG(info) << "[setDeviceProperties] Set int property " << property_item.name << " to " << int_value;
-                } else if (property_item.type == OB_FLOAT_PROPERTY && value.is_a<double>()) {
-                    double float_value = value.get_unchecked<double>();
-                    device->setFloatProperty(property_item.id, float_value);
-                    VIAM_SDK_LOG(info) << "[setDeviceProperties] Set float property " << property_item.name << " to " << float_value;
-                } else if (property_item.type == OB_BOOL_PROPERTY && value.is_a<bool>()) {
-                    bool bool_value = value.get_unchecked<bool>();
-                    device->setBoolProperty(property_item.id, bool_value);
-                    VIAM_SDK_LOG(info) << "[setDeviceProperties] Set bool property " << property_item.name << " to "
-                                       << (bool_value ? "true" : "false");
-                } else {
-                    VIAM_SDK_LOG(warn) << "[setDeviceProperties] Type mismatch or unsupported type for property " << property_item.name
-                                       << ", skipping.";
-                }
-            } catch (ob::Error& e) {
-                std::stringstream error_ss;
-                error_ss << "Failed to set property " << property_item.name << ": " << e.what();
-                VIAM_SDK_LOG(error) << error_ss.str();
-                return {{"error", error_ss.str()}};
-            }
+    std::unordered_set<std::string> writable_properties;
+
+    for (auto const& [name, entry] : properties_map) {
+        auto const& value_struct = entry.template get<viam::sdk::ProtoStruct>();
+        if (!value_struct) {
+            std::stringstream error_ss;
+            error_ss << "Value for property " << name << " is not a struct.";
+            VIAM_SDK_LOG(warn) << error_ss.str();
+            return {{"error", error_ss.str()}};
         }
-    }
-    for (auto const& [name, _] : properties_map) {
-        if (seen_properties.count(name) == 0) {
-            return {{"error", "property not supported: " + name}};
+        if (value_struct->count("current") == 0) {
+            std::stringstream error_ss;
+            error_ss << "Value for property " << name << " is missing 'current' field.";
+            VIAM_SDK_LOG(warn) << error_ss.str();
+            return {{"error", error_ss.str()}};
         }
+        auto const& value = value_struct->at("current");
+
+        viam::sdk::ProtoStruct single_property;
+        single_property[name] = value;
+        auto result = setDeviceProperty(device, viam::sdk::ProtoValue(single_property), command);
+        if (result.count("error") > 0) {
+            return result;
+        }
+        writable_properties.insert(name);
     }
+
     return getDeviceProperties(device, command, writable_properties);
 }
 

--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -239,7 +239,8 @@ viam::sdk::ProtoStruct setDeviceProperty(std::shared_ptr<DeviceT> device,
                 } else {
                     return {{"error", "Unsupported property type"}};
                 }
-                if (err) return *err;
+                if (err)
+                    return *err;
                 VIAM_SDK_LOG(debug) << "[setDeviceProperty] Set property " << property_item.name;
             } catch (ob::Error& e) {
                 std::stringstream error_ss;

--- a/src/module/device_control.hpp
+++ b/src/module/device_control.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <type_traits>
 
 #include <viam/sdk/common/proto_value.hpp>
@@ -7,15 +8,23 @@
 
 namespace device_control {
 
-template <typename T, typename DeviceT>
-void setTypedProperty(std::shared_ptr<DeviceT>& device, OBPropertyID id, T value) {
-    if constexpr (std::is_same_v<T, int>) {
-        device->setIntProperty(id, value);
-    } else if constexpr (std::is_same_v<T, float>) {
-        device->setFloatProperty(id, value);
-    } else if constexpr (std::is_same_v<T, bool>) {
-        device->setBoolProperty(id, value);
+template <typename T, typename ProtoT, typename DeviceT>
+std::optional<viam::sdk::ProtoStruct> validateAndSetProperty(std::shared_ptr<DeviceT>& device,
+                                                             OBPropertyID id,
+                                                             viam::sdk::ProtoValue const& val,
+                                                             std::string const& type_name) {
+    if (!val.is_a<ProtoT>()) {
+        return viam::sdk::ProtoStruct{{"error", "Invalid type for " + type_name + " property"}};
     }
+    T typed_value = val.get_unchecked<ProtoT>();
+    if constexpr (std::is_same_v<T, int>) {
+        device->setIntProperty(id, typed_value);
+    } else if constexpr (std::is_same_v<T, float>) {
+        device->setFloatProperty(id, typed_value);
+    } else if constexpr (std::is_same_v<T, bool>) {
+        device->setBoolProperty(id, typed_value);
+    }
+    return std::nullopt;
 }
 
 inline double depthPrecisionLevelToUnit(OBDepthPrecisionLevel precision) {
@@ -220,27 +229,17 @@ viam::sdk::ProtoStruct setDeviceProperty(std::shared_ptr<DeviceT> device,
             }
             try {
                 auto const& val = property_map.begin()->second;
+                std::optional<viam::sdk::ProtoStruct> err;
                 if (property_item.type == OB_INT_PROPERTY) {
-                    if (!val.is_a<double>()) {
-                        return {{"error", "Invalid type for int property"}};
-                    }
-                    int int_value = val.get_unchecked<double>();
-                    setTypedProperty(device, property_item.id, int_value);
+                    err = validateAndSetProperty<int, double>(device, property_item.id, val, "int");
                 } else if (property_item.type == OB_FLOAT_PROPERTY) {
-                    if (!val.is_a<double>()) {
-                        return {{"error", "Invalid type for float property"}};
-                    }
-                    float float_value = val.get_unchecked<double>();
-                    setTypedProperty(device, property_item.id, float_value);
+                    err = validateAndSetProperty<float, double>(device, property_item.id, val, "float");
                 } else if (property_item.type == OB_BOOL_PROPERTY) {
-                    if (!val.is_a<bool>()) {
-                        return {{"error", "Invalid type for bool property"}};
-                    }
-                    bool bool_value = val.get_unchecked<bool>();
-                    setTypedProperty(device, property_item.id, bool_value);
+                    err = validateAndSetProperty<bool, bool>(device, property_item.id, val, "bool");
                 } else {
                     return {{"error", "Unsupported property type"}};
                 }
+                if (err) return *err;
                 VIAM_SDK_LOG(debug) << "[setDeviceProperty] Set property " << property_item.name;
             } catch (ob::Error& e) {
                 std::stringstream error_ss;

--- a/tests/astra2_test.go
+++ b/tests/astra2_test.go
@@ -152,5 +152,122 @@ func TestCameraServer(t *testing.T) {
 			test.That(t, props.SupportsPCD, test.ShouldBeTrue)
 			test.That(t, props.IntrinsicParams, test.ShouldNotBeNil)
 		})
+
+		t.Run("DoCommand get_device_properties", func(t *testing.T) {
+			resp, err := cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"get_device_properties": "",
+			})
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, resp, test.ShouldNotBeNil)
+			_, hasError := resp["error"]
+			test.That(t, hasError, test.ShouldBeFalse)
+		})
+
+		t.Run("DoCommand set_device_property and verify", func(t *testing.T) {
+			// Get a writable property to test with
+			resp, err := cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"get_device_property": "OB_PROP_COLOR_BRIGHTNESS_INT",
+			})
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, resp, test.ShouldNotBeNil)
+			originalValue, ok := resp["current"].(float64)
+			test.That(t, ok, test.ShouldBeTrue)
+
+			// Set to a new value
+			newValue := originalValue + 1
+			resp, err = cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"set_device_property": map[string]interface{}{
+					"OB_PROP_COLOR_BRIGHTNESS_INT": newValue,
+				},
+			})
+			test.That(t, err, test.ShouldBeNil)
+			_, hasError := resp["error"]
+			test.That(t, hasError, test.ShouldBeFalse)
+
+			// Verify the value was set
+			resp, err = cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"get_device_property": "OB_PROP_COLOR_BRIGHTNESS_INT",
+			})
+			test.That(t, err, test.ShouldBeNil)
+			updatedValue, ok := resp["current"].(float64)
+			test.That(t, ok, test.ShouldBeTrue)
+			test.That(t, updatedValue, test.ShouldEqual, newValue)
+
+			// Restore original value
+			_, err = cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"set_device_property": map[string]interface{}{
+					"OB_PROP_COLOR_BRIGHTNESS_INT": originalValue,
+				},
+			})
+			test.That(t, err, test.ShouldBeNil)
+		})
+
+		t.Run("DoCommand set_device_properties and verify", func(t *testing.T) {
+			// Get current values for two writable properties
+			resp, err := cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"get_device_property": "OB_PROP_COLOR_BRIGHTNESS_INT",
+			})
+			test.That(t, err, test.ShouldBeNil)
+			originalBrightness, ok := resp["current"].(float64)
+			test.That(t, ok, test.ShouldBeTrue)
+
+			resp, err = cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"get_device_property": "OB_PROP_COLOR_CONTRAST_INT",
+			})
+			test.That(t, err, test.ShouldBeNil)
+			originalContrast, ok := resp["current"].(float64)
+			test.That(t, ok, test.ShouldBeTrue)
+
+			// Set both properties at once
+			newBrightness := originalBrightness + 1
+			newContrast := originalContrast + 1
+			resp, err = cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"set_device_properties": map[string]interface{}{
+					"OB_PROP_COLOR_BRIGHTNESS_INT": map[string]interface{}{"current": newBrightness},
+					"OB_PROP_COLOR_CONTRAST_INT":   map[string]interface{}{"current": newContrast},
+				},
+			})
+			test.That(t, err, test.ShouldBeNil)
+			_, hasError := resp["error"]
+			test.That(t, hasError, test.ShouldBeFalse)
+
+			// Verify both values were set
+			resp, err = cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"get_device_property": "OB_PROP_COLOR_BRIGHTNESS_INT",
+			})
+			test.That(t, err, test.ShouldBeNil)
+			updatedBrightness, ok := resp["current"].(float64)
+			test.That(t, ok, test.ShouldBeTrue)
+			test.That(t, updatedBrightness, test.ShouldEqual, newBrightness)
+
+			resp, err = cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"get_device_property": "OB_PROP_COLOR_CONTRAST_INT",
+			})
+			test.That(t, err, test.ShouldBeNil)
+			updatedContrast, ok := resp["current"].(float64)
+			test.That(t, ok, test.ShouldBeTrue)
+			test.That(t, updatedContrast, test.ShouldEqual, newContrast)
+
+			// Restore original values
+			_, err = cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"set_device_properties": map[string]interface{}{
+					"OB_PROP_COLOR_BRIGHTNESS_INT": map[string]interface{}{"current": originalBrightness},
+					"OB_PROP_COLOR_CONTRAST_INT":   map[string]interface{}{"current": originalContrast},
+				},
+			})
+			test.That(t, err, test.ShouldBeNil)
+		})
+
+		t.Run("DoCommand set_device_property unsupported property", func(t *testing.T) {
+			resp, err := cam.DoCommand(timeoutCtx, map[string]interface{}{
+				"set_device_property": map[string]interface{}{
+					"NonExistentProperty": 42,
+				},
+			})
+			test.That(t, err, test.ShouldBeNil)
+			errMsg, hasError := resp["error"]
+			test.That(t, hasError, test.ShouldBeTrue)
+			test.That(t, errMsg, test.ShouldContainSubstring, "not supported")
+		})
 	})
 }


### PR DESCRIPTION
## Description

Simple PR to clean up device property setting

## Testing

- Manually tested call_get_properties on amd64

```json
{"set_device_properties": 
{"OB_PROP_COLOR_AUTO_EXPOSURE_BOOL": {"current": false},
"OB_PROP_COLOR_EXPOSURE_INT": {"current": 33000}}}     
```

https://github.com/user-attachments/assets/e869ca1b-8cff-47b2-bdc3-cda5e09e5efa

## Review

1 approval