### PR TITLE
[RSDK-13824] Fix depth image scale by applying Orbbec SDK valueScale

### DIFF
--- a/src/module/encoding.cpp
+++ b/src/module/encoding.cpp
@@ -3,22 +3,24 @@
 namespace orbbec {
 namespace encoding {
 
-std::vector<std::uint8_t> encode_to_depth_raw(std::uint8_t const* const data, std::uint32_t const width, std::uint32_t const height) {
+std::vector<std::uint8_t> encode_to_depth_raw(std::uint8_t const* const data,
+                                              std::uint32_t const width,
+                                              std::uint32_t const height,
+                                              float valueScale) {
+    // The Orbbec SDK returns raw uint16_t depth pixels whose unit depends on the sensor.
+    // getValueScale() returns the multiplier needed to convert a raw pixel to millimeters:
+    //   actual_distance_mm = raw_pixel * valueScale
+    // The Viam depth map format stores uint16_t values in millimeters, so we apply the
+    // scale and round to the nearest integer mm before encoding.
     viam::sdk::Camera::depth_map m = xt::xarray<uint16_t>::from_shape({height, width});
-    std::copy(reinterpret_cast<const uint16_t*>(data), reinterpret_cast<const uint16_t*>(data) + height * width, m.begin());
-
-    double const mmToMeterMultiplier = 0.001;
-
-    for (size_t i = 0; i < m.size(); i++) {
-        auto const rounded_value = std::lround(m[i] * mmToMeterMultiplier * 1000.0) / 1000.0;
-        // Let's make sure rounded_value is within the range of uint16_t after conversion to mm using numeric limits of depth_map
-        // If it's out of range, we throw an exception
-        if (rounded_value < 0 || rounded_value > std::numeric_limits<viam::sdk::Camera::depth_map::value_type>::max()) {
+    const uint16_t* rawData = reinterpret_cast<const uint16_t*>(data);
+    for (size_t i = 0; i < height * width; i++) {
+        long mm = std::lround(rawData[i] * static_cast<double>(valueScale));
+        if (mm < 0 || mm > std::numeric_limits<viam::sdk::Camera::depth_map::value_type>::max()) {
             throw std::out_of_range("Depth value out of range");
         }
-        m[i] = rounded_value;
+        m[i] = static_cast<uint16_t>(mm);
     }
-
     return viam::sdk::Camera::encode_depth_map(m);
 }
 

--- a/src/module/encoding.cpp
+++ b/src/module/encoding.cpp
@@ -16,10 +16,7 @@ std::vector<std::uint8_t> encode_to_depth_raw(std::uint8_t const* const data,
     const uint16_t* rawData = reinterpret_cast<const uint16_t*>(data);
     for (size_t i = 0; i < height * width; i++) {
         long mm = std::lround(rawData[i] * static_cast<double>(valueScale));
-        if (mm < 0 || mm > std::numeric_limits<viam::sdk::Camera::depth_map::value_type>::max()) {
-            throw std::out_of_range("Depth value out of range");
-        }
-        m[i] = static_cast<uint16_t>(mm);
+        m[i] = static_cast<uint16_t>(std::clamp(mm, 0L, static_cast<long>(std::numeric_limits<uint16_t>::max())));
     }
     return viam::sdk::Camera::encode_depth_map(m);
 }

--- a/src/module/encoding.hpp
+++ b/src/module/encoding.hpp
@@ -8,7 +8,10 @@
 namespace orbbec {
 namespace encoding {
 
-std::vector<std::uint8_t> encode_to_depth_raw(std::uint8_t const* const data, std::uint32_t const width, std::uint32_t const height);
+std::vector<std::uint8_t> encode_to_depth_raw(std::uint8_t const* const data,
+                                              std::uint32_t const width,
+                                              std::uint32_t const height,
+                                              float valueScale);
 std::vector<std::uint8_t> encode_to_png(std::uint8_t const* const image_data, std::uint32_t const width, std::uint32_t const height);
 }  // namespace encoding
 }  // namespace orbbec

--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -1407,11 +1407,12 @@ vsdk::Camera::image_collection Orbbec::get_images(std::vector<std::string> filte
                 throw std::runtime_error("[get_images] depth data is null");
             }
             auto depthVid = depth->as<ob::VideoFrame>();
+            float valueScale = depth->as<ob::DepthFrame>()->getValueScale();
 
             vsdk::Camera::raw_image depth_image;
             depth_image.source_name = kDepthSourceName;
             depth_image.mime_type = kDepthMimeTypeViamDep;
-            depth_image.bytes = encoding::encode_to_depth_raw(depthData, depthVid->getWidth(), depthVid->getHeight());
+            depth_image.bytes = encoding::encode_to_depth_raw(depthData, depthVid->getWidth(), depthVid->getHeight(), valueScale);
             response.images.emplace_back(std::move(depth_image));
         }
 


### PR DESCRIPTION
The previous implementation divided raw depth values by 1000 before storing them as uint16_t mm values, compressing all distances into the 0-1 mm range. Additionally, getValueScale() was never applied, meaning cameras with a non-1.0 scale factor would produce wrong values.

Now encode_to_depth_raw accepts a valueScale parameter and computes actual_mm = raw_pixel * valueScale before encoding.

This fix is based on the example from Orbbec: https://github.com/orbbec/OrbbecSDK_v2/tree/main/examples/1.stream.depth 

## Test (using a simple python script to print the images we receive from the camera)
### Before:
<img width="1200" height="500" alt="color_and_depth_bug" src="https://github.com/user-attachments/assets/6fc015bd-ea92-404f-b19d-dbf916b97085" />

### After:
<img width="1200" height="500" alt="color_and_depth_fixed" src="https://github.com/user-attachments/assets/020790ec-1b9a-42eb-a264-6097f6337be7" />
