### PR TITLE
Anchor camera geometry to the RGB sensor and add Gemini 335Le values

### DIFF
--- a/src/module/orbbec.cpp
+++ b/src/module/orbbec.cpp
@@ -67,6 +67,12 @@ const uint64_t maxFrameSetTimeDiffUs =
     2000;  // max time difference between frames in a frameset to be considered simultaneous, in microseconds (equal to 2 ms)
 
 // Model configurations
+//
+// The body_box / body_box_pose values are derived from the vendor mechanical drawings:
+//   Astra 2:      https://d1cd332k3pgc17.cloudfront.net/wp-content/uploads/2023/04/ORBBEC_Datasheet_Astra-2_V1.1.pdf
+//   Gemini 335Le: https://new-orbbec3d-s3.s3.amazonaws.com/wp-content/uploads/2025/03/24023151/Orbbec-Gemini-335Le-Datasheet-V1-2.pdf
+// Both use the optical frame convention the Gemini 335Le datasheet spells out in section 4.8:
+// +X to the right, +Y down, +Z out of the lens.
 namespace {
 static const OrbbecModelConfig ASTRA2_CONFIG{
     {"Orbbec Astra 2", "Orbbec Astra2"},                                                   // model_names
@@ -84,7 +90,19 @@ static const OrbbecModelConfig ASTRA2_CONFIG{
     {"RGB", "MJPG"},                                                                       // supported_color_formats
     {"Y16"},                                                                               // supported_depth_formats
     "MJPG",                                                                                // default_color_format
-    "Y16"                                                                                  // default_depth_format
+    "Y16",                                                                                 // default_depth_format
+    // Body measures 144.54 x 45.35 x 38.64mm including the mounting base, which the box covers
+    // because it is bolted to the camera.
+    {144.54, 45.35, 38.64},  // body_box
+    // x: the LDM and IR modules straddle the body symmetrically (75mm baseline), putting the body
+    //    center 37.50mm from the LDM. RGB sits 56.50mm from the LDM, so the body center is 19.00mm
+    //    towards the LDM from RGB.
+    // y: the modules sit on the body's horizontal centerline, which is 5.47mm above the center of
+    //    the box because the box also spans the mounting base hanging below the body.
+    // z: assumes the optical center lies on the front glass, which is the front face of the box.
+    //    Orbbec does not publish a start point offset for the Astra 2 the way it does for the
+    //    Gemini 335Le, so this is out by however far the sensor sits behind the glass.
+    {{19.00, 5.47, -19.32}}  // body_box_pose
 };
 
 static const OrbbecModelConfig GEMINI_335LE_CONFIG{
@@ -101,7 +119,19 @@ static const OrbbecModelConfig GEMINI_335LE_CONFIG{
     {"MJPG"},                                                                                 // supported_color_formats
     {"Y16"},                                                                                  // supported_depth_formats
     "MJPG",                                                                                   // default_color_format
-    "Y16"                                                                                     // default_depth_format
+    "Y16",                                                                                    // default_depth_format
+    // Body measures 124.02 x 29.03 x 51.20mm. The depth is taken from the right view rather than
+    // the 50mm quoted in the spec table, because the rear M12 connector protrudes 1.20mm past the
+    // housing.
+    {124.02, 29.03, 51.20},  // body_box
+    // x: the two IR modules straddle the body symmetrically (95mm baseline), putting the body
+    //    center 47.50mm from the right IR module. RGB sits 71.25mm from it, so the body center is
+    //    23.75mm towards the right IR module from RGB.
+    // y: the modules sit on the body's horizontal centerline and nothing hangs below the body, so
+    //    the box center is on the optical axis.
+    // z: datasheet section 4.9 puts the RGB start point 4.08mm behind the front glass, and the box
+    //    center is half of 51.20mm behind that same glass.
+    {{23.75, 0.00, -21.52}}  // body_box_pose
 };
 
 static const std::vector<OrbbecModelConfig> all_model_configs = {ASTRA2_CONFIG, GEMINI_335LE_CONFIG};
@@ -1775,9 +1805,10 @@ vsdk::Camera::point_cloud Orbbec::get_point_cloud(std::string mime_type, const v
 }
 
 std::vector<vsdk::GeometryConfig> Orbbec::get_geometries(const vsdk::ProtoStruct& extra) {
-    // see https://github.com/viam-modules/orbbec/pull/16 for explanation of geometry config values
-    // If we add support for models other than the astra 2 these values can't be hardcoded.
-    return {vsdk::GeometryConfig(vsdk::pose{-37.5, 5.5, -18.1}, vsdk::box({145, 46, 39}), "box")};
+    if (!model_config_.has_value()) {
+        throw std::runtime_error("failed to create geometries: no Orbbec model detected");
+    }
+    return {vsdk::GeometryConfig(model_config_->body_box_pose, model_config_->body_box, "box")};
 }
 
 std::unique_ptr<orbbec::ObResourceConfig> Orbbec::configure(vsdk::Dependencies dependencies, vsdk::ResourceConfig configuration) {

--- a/src/module/orbbec.hpp
+++ b/src/module/orbbec.hpp
@@ -1,7 +1,9 @@
 #pragma once
+#include <viam/sdk/common/pose.hpp>
 #include <viam/sdk/components/camera.hpp>
 #include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/resource/reconfigurable.hpp>
+#include <viam/sdk/spatialmath/geometry.hpp>
 
 #include <libobsensor/ObSensor.hpp>
 
@@ -120,6 +122,13 @@ struct OrbbecModelConfig {
     std::string default_color_format;
     std::string default_depth_format;
 
+    // Bounding box of the camera body, and the pose of that box's center. The pose is expressed
+    // in the color sensor's optical frame, since that is the frame this module reports all of its
+    // data in: get_properties returns the RGB intrinsics and the point cloud is depth-to-color
+    // aligned. The color sensor is not centered on the body, so the box center is offset from it.
+    viam::sdk::box body_box;
+    viam::sdk::pose body_box_pose;
+
     // Get config for a device name
     static std::optional<OrbbecModelConfig> forDevice(const std::string& device_name);
 
@@ -161,7 +170,6 @@ class Orbbec final : public viam::sdk::Camera, public viam::sdk::Reconfigurable 
     static std::vector<std::string> validateAstra2(viam::sdk::ResourceConfig cfg);
     static std::vector<std::string> validateGemini335Le(viam::sdk::ResourceConfig cfg);
     static std::vector<std::string> validateOrbbecModel(viam::sdk::ResourceConfig cfg, OrbbecModelConfig const& modelConfig);
-    static viam::sdk::GeometryConfig geometry;
     static viam::sdk::Model model_astra2;
     static viam::sdk::Model model_gemini_335le;
 

--- a/tests/astra2_test.go
+++ b/tests/astra2_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/geo/r3"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/utils"
 	"go.viam.com/test"
 	"go.viam.com/utils/rpc"
@@ -156,6 +158,23 @@ func TestCameraServer(t *testing.T) {
 			test.That(t, props, test.ShouldNotBeNil)
 			test.That(t, props.SupportsPCD, test.ShouldBeTrue)
 			test.That(t, props.IntrinsicParams, test.ShouldNotBeNil)
+		})
+
+		t.Run("Get geometries method", func(t *testing.T) {
+			geometries, err := cam.Geometries(timeoutCtx, nil)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, len(geometries), test.ShouldEqual, 1)
+
+			// The pose is the center of the camera body relative to the RGB sensor's optical
+			// center, which is the frame the module reports its data in. See the derivation on
+			// ASTRA2_CONFIG in src/module/orbbec.cpp.
+			expected, err := spatialmath.NewBox(
+				spatialmath.NewPoseFromPoint(r3.Vector{X: 19.00, Y: 5.47, Z: -19.32}),
+				r3.Vector{X: 144.54, Y: 45.35, Z: 38.64},
+				"box",
+			)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, spatialmath.GeometriesAlmostEqual(geometries[0], expected), test.ShouldBeTrue)
 		})
 
 		t.Run("DoCommand get_device_properties", func(t *testing.T) {

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,6 +3,7 @@ module github.com/orbbec/tests
 go 1.25.9
 
 require (
+	github.com/golang/geo v0.0.0-20230421003525-6adc56603217
 	go.viam.com/rdk v1.0.0
 	go.viam.com/test v1.2.4
 	go.viam.com/utils v0.6.6
@@ -93,7 +94,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
-	github.com/golang/geo v0.0.0-20230421003525-6adc56603217 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect


### PR DESCRIPTION
## Summary

`get_geometries` returned a bounding box positioned relative to the Astra 2's **LDM** (the laser dot projector), but the module reports all of its data in the **color sensor's** optical frame — `get_properties` returns the RGB intrinsics and the point cloud is produced through depth-to-color alignment. Since the RGB module is not centered on the camera body, the returned box was displaced **56.5mm** along the camera's X axis, roughly 39% of the camera's own length. The values were also hardcoded to the Astra 2, so a Gemini 335Le reported the Astra 2's box entirely.

## Changes

- **src/module/orbbec.hpp**: Add `body_box` / `body_box_pose` to `OrbbecModelConfig` so the geometry lives alongside the other per-model data; drop the dead `static viam::sdk::GeometryConfig geometry;` declaration (declared, never defined or used).
- **src/module/orbbec.cpp**: Re-anchor the Astra 2 box to the RGB optical center and add Gemini 335Le values, both derived from the vendor mechanical drawings; `get_geometries` now dispatches off `model_config_` instead of returning hardcoded values.
- **tests/astra2_test.go**: Add a `Get geometries method` subtest asserting the Astra 2 box and pose.
- **tests/go.mod**: Promote `github.com/golang/geo` to a direct dependency (`go mod tidy`), now used by the new test.

### Values
<img width="839" height="726" alt="Screenshot 2026-07-28 at 10 22 26 AM" src="https://github.com/user-attachments/assets/cc84c013-8900-4060-a2d7-58aa334111a8" />
On this robot the camera should be roughly centered relative to the box representing the end effector. The geometry is very offset

| | before | after |
|---|---|---|
| Astra 2 pose | `{-37.5, 5.5, -18.1}` | `{19.00, 5.47, -19.32}` |
| Astra 2 box | `{145, 46, 39}` | `{144.54, 45.35, 38.64}` |
| Gemini 335Le pose | *(Astra 2's)* | `{23.75, 0.00, -21.52}` |
| Gemini 335Le box | *(Astra 2's)* | `{124.02, 29.03, 51.20}` |

Derivations are documented inline next to each model config. Both use the optical frame convention the Gemini 335Le datasheet states in §4.8 (+X right, +Y down, +Z out of the lens), which is corroborated by its own published Depth→Color offset of +23.75mm.

Two secondary corrections to the Astra 2 numbers:
- `z` was `36.20 / 2` — the **mounting base footprint depth** — rather than `38.64 / 2`, the depth of the box actually being returned.
- Box dimensions now use the datasheet's exact `144.54 x 45.35 x 38.64` instead of rounded values, so the pose and the box stay consistent with each other.

The Gemini box depth uses the right view's `51.20mm` rather than the `50mm` quoted in the spec table, because the rear M12 connector protrudes past the housing and a collision box should not be undersized.

## Testing

- `tests/astra2_test.go` — new `Get geometries method` subtest compares the returned geometry against an expected `spatialmath.NewBox` via `GeometriesAlmostEqual`. This is a hardware-in-the-loop test and needs a connected Astra 2.
- `go vet ./...` passes in `tests/`.
- The neither-datasheet-prints-it number — where the lens array sits relative to the body outline — was verified by measuring the 600dpi drawings: Astra 2 body center **37.51mm** from the LDM (assumed 37.50), Gemini **47.46mm** from the right IR (assumed 47.50). The measured scale reproduced every printed dimension to ~0.1mm.

### For reviewers

- **Not verified on hardware.** The values come from the drawings, not from a measured camera.
- The Astra 2 `z` assumes the RGB optical center sits on the front glass. Orbbec publishes a start-point offset for the Gemini 335Le (4.08mm behind the glass, §4.9) but not for the Astra 2, so that value is off by however far the sensor actually sits back.
- The full C++ build was not run locally: at `cppstd=17` the SDK requests `xtensor/[>=0.24.3]`, which now resolves to 0.27.1 and requires C++20. That break is independent of this change and needs its own fix, but it means CI is the first real compile of this branch.

## Claude Code Prompts Used

- "Hi Claude, there is an issue with the orbbec camera Viam model. Its geometry is wrong. When we set the frame of the camera component we will set the frame to match the RGB sensor. However the RGB sensor is not centered on the camera. We need to account for the offset in the geometry we are returning and it does not look like we are doing so. Can you look into it?"
- "Can you search the internet for the datasheet for both models of the camera and then adjust the geometries?"
- "let's commit, push and open a PR"

🤖 Generated with [Claude Code](https://claude.com/claude-code)