### PR TITLE
ci: cache ~/.conan2 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,15 @@ jobs:
       - name: Install deps
         run: choco install -y conan git
 
+      # Skips the Conan rebuild of viam-cpp-sdk on cache hit.
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
       - name: Set up python/conan
         shell: powershell
         # Powershell will not exit on error without the line below...highly vexing.
@@ -78,6 +87,16 @@ jobs:
           sudo apt update -y
           apt upgrade -y
           apt install -y cmake python3.11 python3.11-venv wget
+
+      # Skips the Conan rebuild of viam-cpp-sdk on cache hit. matrix.os keeps
+      # amd64 / arm64 / macos in separate namespaces.
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ matrix.os }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ matrix.os }}-
 
       - name: Set up python/conan
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,9 @@ jobs:
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv
 
-          conan profile detect
+          conan profile detect --force
 
-          conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0
+          conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0 --force
 
         env:
           CONAN_USER_HOME: c:/cache
@@ -102,8 +102,8 @@ jobs:
         run: |
           python3 -m venv venv && . ./venv/bin/activate
           python3 -m pip install conan
-          conan profile detect
-          conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0
+          conan profile detect --force
+          conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0 --force
 
       - name: Build package and module
         run: |


### PR DESCRIPTION
Cache `~/.conan2` on both jobs in `build.yml`, keyed on `conanfile.py` - matches what i've done in ensenso/zivid/zed/realsense.

Nix matrix uses `matrix.os` so `ubuntu-22.04`, `ubuntu-22.04-arm`, and `macos-latest` get separate caches.

Expected: warm runs drop from ~80 min to ~10–15 min. Cold runs and SDK-bump runs unchanged.

**You can see from the ci time went from 1hr+ to 7min**
