### PR TITLE
Revert "ci: cache ~/.conan2 in build workflow"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,15 +18,6 @@ jobs:
       - name: Install deps
         run: choco install -y conan git
 
-      # Skips the Conan rebuild of viam-cpp-sdk on cache hit.
-      - name: Cache Conan packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.conan2
-          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: |
-            conan-${{ runner.os }}-
-
       - name: Set up python/conan
         shell: powershell
         # Powershell will not exit on error without the line below...highly vexing.
@@ -36,9 +27,9 @@ jobs:
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv
 
-          conan profile detect --force
+          conan profile detect
 
-          conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0 --force
+          conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0
 
         env:
           CONAN_USER_HOME: c:/cache
@@ -88,22 +79,12 @@ jobs:
           apt upgrade -y
           apt install -y cmake python3.11 python3.11-venv wget
 
-      # Skips the Conan rebuild of viam-cpp-sdk on cache hit. matrix.os keeps
-      # amd64 / arm64 / macos in separate namespaces.
-      - name: Cache Conan packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.conan2
-          key: conan-${{ matrix.os }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: |
-            conan-${{ matrix.os }}-
-
       - name: Set up python/conan
         run: |
           python3 -m venv venv && . ./venv/bin/activate
           python3 -m pip install conan
-          conan profile detect --force
-          conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0 --force
+          conan profile detect
+          conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0
 
       - name: Build package and module
         run: |


### PR DESCRIPTION
Reverts viam-modules/orbbec#84

lost this in my github notifications, but just recording for posterity that caching conan with github actions is basically always an error, for a couple reasons. the simplest one is that this is the exact purpose of the viam artifactory server, so it's an antipattern to be caching on top of a dedicated, purpose-built cache.

the more complex reason is that github actions caching is not fit to purpose for the level of granularity used by conan to cache binary artifacts, and attempts to distinguish github cache artifacts, eg by runner name or platform, will still lead to collisions and races which show up in basically any nontrivial CI matrix. 

looking ahead it would be good if we had a canonical "good example" to point people at for how this should be done, which is that CI jobs should use a lockfile to pin dependency versions, and periodically upload dependencies to the viam conan server if they're slowing down CI 