### PR TITLE
Remove local sdk build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           - platform: linux/arm64
             os: ubuntu-22.04-arm
             container:
-              image: ghcr.io/viam-modules/orbbec/viam-cpp-base-orin:0.0.1
+              image: ghcr.io/viam-modules/orbbec/viam-cpp-base-orin:0.0.2
             artifact-name: module-linux-arm64
           - platform: windows/amd64
             # pin instead of using windows-latest which was recently bumped to a version that breaks conan

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ TAG_VERSION?=latest
 # Docker image
 HUB_USER := viam-modules/orbbec
 BASE_NAME := viam-cpp-base-orin
-BASE_TAG := 0.0.1
+BASE_TAG := 0.0.2
 
 .PHONY: build lint setup conan-pkg
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ clean:
 
 clean-all: clean
 	rm -rf build-conan
-	rm -rf tmp_cpp_sdk
 	rm -rf venv
 	rm -f orbbec-test-bin
 	rm -f $(OUTPUT_NAME)

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -37,33 +37,7 @@ if (-not (Test-Path $conanExe)) {
 conan profile detect
 if (!$?) { Write-Host "Conan is already installed" }
 
-# Clone the C++ SDK repo
-mkdir tmp_cpp_sdk
-Push-Location tmp_cpp_sdk
-git clone https://github.com/viamrobotics/viam-cpp-sdk.git
-Push-Location viam-cpp-sdk
-
-# NOTE: If you change this version, also change it in the `conanfile.py` requirements
-# and in dockerfile
-git checkout releases/v0.38.1
-
-# Build the C++ SDK repo.
-#
-# We want a static binary, so we turn off shared. Elect for C++17
-# compilation, since it seems some of the dependencies we pick mandate
-# it anyway. Pin to the Windows 10 1809 associated windows SDK, and
-# opt for the static compiler runtime so we don't have a dependency on
-# the VC redistributable.
-#
-# boost backtrace contains a unix only library dlfcn.h
-conan create . `
-      --build=missing `
-      -o:a "&:shared=False" `
-      -o:a "boost/*:with_stacktrace_backtrace=False" `
-      -o:a "boost/*:without_stacktrace=True" `
-      -s:a build_type=Release `
-      -s:a compiler.cppstd=17
-
-Pop-Location  # viam-cpp-sdk
-Pop-Location  # tmp_cpp_sdk
-Remove-Item -Recurse -Force tmp_cpp_sdk
+# Add the viam conan remote so viam-cpp-sdk (pinned in conanfile.py) resolves
+# from there instead of being cloned and built from source here.
+conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0 --force
+if (!$?) { throw "Failed to add viamconan remote" }

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -42,33 +42,6 @@ fi
 
 conan profile detect || echo "Conan is already installed"
 
-if [ ! -d "tmp_cpp_sdk/viam-cpp-sdk" ]; then
-  # Clone the C++ SDK repo
-  mkdir -p tmp_cpp_sdk
-  pushd tmp_cpp_sdk
-  git clone https://github.com/viamrobotics/viam-cpp-sdk.git
-  pushd viam-cpp-sdk
-else
-  pushd tmp_cpp_sdk
-  pushd viam-cpp-sdk
-fi
-
-# NOTE: If you change this version, also change it in the `conanfile.py` requirements
-# and in the Dockerfile
-git checkout releases/v0.38.1
-
-# Build the C++ SDK repo
-#
-# We want a static binary, so we turn off shared. Elect for C++17
-# compilation, since it seems some of the dependencies we pick mandate
-# it anyway.
-conan create . \
-      --build=missing \
-      -o:a "&:shared=False" \
-      -s:a build_type=Release \
-      -s:a compiler.cppstd=17
-
-# Cleanup
-popd  # viam-cpp-sdk
-popd  # tmp_cpp_sdk
-rm -rf tmp_cpp_sdk
+# Add the viam conan remote so viam-cpp-sdk (pinned in conanfile.py) resolves
+# from there instead of being cloned and built from source here.
+conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0 --force

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ class orbbec(ConanFile):
 
     def requirements(self):
         # NOTE: If you update the `viam-cpp-sdk` dependency here, it
-        # should also be updated in `bin/setup.{sh,ps1}`, and in the Dockerfile.
+        # should also be updated in the Dockerfile.
         self.requires("viam-cpp-sdk/0.38.1")
         self.requires("openssl/[>=3 <4]")
         self.requires("libcurl/8.9.1")

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,8 +26,6 @@ class orbbec(ConanFile):
         self.version = re.search("set\(CMAKE_PROJECT_VERSION (.+)\)", content).group(1).strip()
 
     def requirements(self):
-        # NOTE: If you update the `viam-cpp-sdk` dependency here, it
-        # should also be updated in the Dockerfile.
         self.requires("viam-cpp-sdk/0.38.1")
         self.requires("openssl/[>=3 <4]")
         self.requires("libcurl/8.9.1")

--- a/etc/Dockerfile.ubuntu.jammy
+++ b/etc/Dockerfile.ubuntu.jammy
@@ -48,7 +48,9 @@ RUN python3 -m pip install conan
 RUN conan profile detect
 
 # NOTE: If you update the `viam-cpp-sdk` dependency here, it
-# should also be updated in `bin/setup.{sh,ps1}`, and in the conanfile.py.
+# should also be updated in the conanfile.py.
+# TODO: once the viamconan remote serves one revision per release with all
+# platform binaries, drop this source build and add the remote instead.
 RUN git clone https://github.com/viamrobotics/viam-cpp-sdk.git \
     --branch releases/v0.38.1 --depth=1 && \
     cd viam-cpp-sdk && \

--- a/etc/Dockerfile.ubuntu.jammy
+++ b/etc/Dockerfile.ubuntu.jammy
@@ -47,15 +47,5 @@ RUN python3 -m venv venv && . ./venv/bin/activate
 RUN python3 -m pip install conan
 RUN conan profile detect
 
-# NOTE: If you update the `viam-cpp-sdk` dependency here, it
-# should also be updated in the conanfile.py.
-# TODO: once the viamconan remote serves one revision per release with all
-# platform binaries, drop this source build and add the remote instead.
-RUN git clone https://github.com/viamrobotics/viam-cpp-sdk.git \
-    --branch releases/v0.38.1 --depth=1 && \
-    cd viam-cpp-sdk && \
-    conan create . \
-    --build=missing \
-    -o:a "&:shared=False" \
-    -s:a build_type=Release \
-    -s:a compiler.cppstd=17
+# viam-cpp-sdk (pinned in conanfile.py) resolves from this remote at build time.
+RUN conan remote add viamconan https://viam.jfrog.io/artifactory/api/conan/viamconan --index 0 --force


### PR DESCRIPTION
## Description

setup.sh/setup.ps1 cloned viam-cpp-sdk and built it from source with a hardcoded version tag, duplicating the pin in conanfile.py. Setup now jus adds the viamconan remote and the SDK resolves from there at build time, same as CI  already does. The pin lives in conanfile.py only. Also dropped the SDK bake from the orin base image Dockerfile (takes effect on next image rebuild/push).

## Tests
- canon make setup with a clean conan cache, verified SDK recipe downloads
  from viamconan and canon make build produces the module

## Follow-up: do we need the base image at all?

This PR bumps the base image tag to 0.0.2 (so the slimmed rebuild doesn't silently replace 0.0.1 under publish.yml) — note 0.0.2 must be built/pushed (`make image-base && make push-base`) before the next release, or the arm64 publish leg fails to pull.

Longer term the custom image is probably unnecessary. Its only remaining job is pinning the build env to Ubuntu jammy (glibc 2.35) so the published arm64 binary loads on Jetson Orin / JetPack 6; `rdk-devenv:arm64` is bookworm (glibc 2.36), too new. But a stock `container: ubuntu:jammy` + an apt-install step in publish.yml gives the same pin with no image to build, push, or version — and would let us delete the Dockerfile and the `image-base`/`push-base` targets entirely.
